### PR TITLE
Refactor LEGO pipeline to canonical offers schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Repositorio central para el proyecto **Compustar**, integraciones y scripts rela
 3. Guardar resultados en `data/exports/`
 4. Documentar cambios relevantes en `docs/`
 
+### Diccionario canónico LEGO
+
+- Las etapas 02 ➜ 09 trabajan ahora con el diccionario canónico (`cost_usd`, `exchange_rate`, `stock_total`, etc.).
+- Consulta `docs/schema_contract.md` para el detalle de claves y el esquema actualizado de `wp_compu_offers`.
+
 > Roles/RACI/DoD: ver documento “Equipo y responsabilidades” y la sección de operación del diario.
 <!-- END:CCX_REPOS_SUMMARY -->
 > Roles/RACI/DoD: ver documento “Equipo y responsabilidades” y la sección de operación del diario.

--- a/db/migrations/20251005_compu_offers_canonical.sql
+++ b/db/migrations/20251005_compu_offers_canonical.sql
@@ -1,0 +1,47 @@
+-- Actualiza wp_compu_offers al esquema canónico.
+-- Ejecutar en la base de datos de WordPress antes de desplegar los stages.
+
+ALTER TABLE `wp_compu_offers`
+  ADD COLUMN IF NOT EXISTS `cost_usd` DECIMAL(12,4) NULL AFTER `supplier_sku`,
+  ADD COLUMN IF NOT EXISTS `exchange_rate` DECIMAL(10,4) NULL AFTER `cost_usd`,
+  ADD COLUMN IF NOT EXISTS `stock_total` INT NULL AFTER `exchange_rate`,
+  ADD COLUMN IF NOT EXISTS `stock_main` INT NULL AFTER `stock_total`,
+  ADD COLUMN IF NOT EXISTS `stock_tijuana` INT NULL AFTER `stock_main`,
+  ADD COLUMN IF NOT EXISTS `stock_by_branch_json` LONGTEXT NULL AFTER `stock_tijuana`;
+
+-- Migra datos antiguos si existían columnas legacy
+UPDATE `wp_compu_offers`
+  SET `cost_usd` = COALESCE(`cost_usd`, `price_cost`, `price_usd`);
+UPDATE `wp_compu_offers`
+  SET `exchange_rate` = COALESCE(`exchange_rate`, `tipo_cambio`);
+UPDATE `wp_compu_offers`
+  SET `stock_total` = COALESCE(`stock_total`, `stock`);
+
+ALTER TABLE `wp_compu_offers`
+  DROP COLUMN IF EXISTS `price_cost`,
+  DROP COLUMN IF EXISTS `price_usd`,
+  DROP COLUMN IF EXISTS `stock`;
+
+ALTER TABLE `wp_compu_offers`
+  DROP INDEX IF EXISTS `uniq_offer`,
+  ADD UNIQUE KEY IF NOT EXISTS `uniq_supplier_source` (`supplier_sku`,`source`),
+  ADD KEY IF NOT EXISTS `product_source` (`product_id`,`source`);
+
+CREATE OR REPLACE VIEW `wp_compu_offers_legacy` AS
+  SELECT
+    id,
+    product_id,
+    source,
+    supplier_sku,
+    cost_usd AS price_cost,
+    exchange_rate,
+    stock_total AS stock,
+    stock_main,
+    stock_tijuana,
+    stock_by_branch_json,
+    currency,
+    offer_hash,
+    valid_from,
+    created_at,
+    updated_at
+  FROM `wp_compu_offers`;

--- a/docs/schema_contract.md
+++ b/docs/schema_contract.md
@@ -2,6 +2,57 @@
 
 Este documento resume tablas detectadas en el dump y servirá como contrato de referencia para desarrollo.
 
+## Diccionario canónico LEGO
+
+| Clave | Descripción |
+|---|---|
+| `sku` | Identificador principal del producto (SKU Syscom) utilizado en todo el pipeline. |
+| `supplier_sku` | SKU entregado por el proveedor (mismo valor que `sku` para Syscom, reservado para futuros proveedores). |
+| `brand` | Marca o fabricante normalizado. |
+| `model` | Modelo o referencia de fabricante. |
+| `title` | Título descriptivo corto. |
+| `name` | Nombre amigable construido (`brand` + `model` + `title`). |
+| `description_html` | Descripción en HTML; alias `description`. |
+| `image_url` | URL principal de imagen; alias `image`. |
+| `cost_usd` | Costo base del proveedor expresado en USD. |
+| `list_price_usd` | Precio de lista del proveedor, cuando existe. |
+| `special_price_usd` | Precio promocional del proveedor. |
+| `exchange_rate` | Tipo de cambio aplicado al costo. |
+| `stock_total` | Existencias totales disponibles. |
+| `stock_main` | Existencias fuera de Tijuana (almacén 15). |
+| `stock_tijuana` | Existencias en Tijuana (almacén 15 TJ). |
+| `stock_by_branch` | Mapa JSON con inventario por sucursal detectada. |
+| `weight_kg` | Peso en kilogramos. |
+| `tax_code` | Clave fiscal o CFDI asociado. |
+| `lvl1_id`, `lvl2_id`, `lvl3_id` | Identificadores jerárquicos del menú Syscom. |
+
+### Tabla `wp_compu_offers` (esquema canónico 2025-10)
+
+| Columna | Tipo | Notas |
+|---|---|---|
+| `id` | `bigint` | PK autoincremental. |
+| `product_id` | `bigint` | `wp_posts.ID` del producto WooCommerce (nullable mientras se resuelve el match). |
+| `source` | `varchar(64)` | Identificador del proveedor/origen (`syscom`, etc.). |
+| `supplier_sku` | `varchar(191)` | SKU suministrado por el proveedor. Único junto con `source`. |
+| `cost_usd` | `decimal(12,4)` | Costo base en USD. |
+| `exchange_rate` | `decimal(10,4)` | Tipo de cambio aplicado. |
+| `stock_total` | `int` | Inventario total disponible. |
+| `stock_main` | `int` | Inventario fuera de Tijuana. |
+| `stock_tijuana` | `int` | Inventario correspondiente a Tijuana. |
+| `stock_by_branch_json` | `longtext` | JSON con inventario por sucursal (llaves `stock_*`). |
+| `currency` | `char(3)` | Moneda del costo (por default `USD`). |
+| `offer_hash` | `char(32)` | Huella para detectar cambios (opcional). |
+| `valid_from` | `datetime` | Inicio de vigencia de la oferta. |
+| `created_at` | `datetime` | Timestamp de creación. |
+| `updated_at` | `datetime` | Timestamp de última sincronización. |
+| `supplier` | `varchar(50)` | Nombre corto del proveedor (metadata). |
+| `warehouse_id` | `int` | Identificador interno de almacén. |
+| `warehouse_code` | `varchar(50)` | Código textual de almacén. |
+| `lead_time_days` | `int` | Tiempo de entrega estimado. |
+| `is_refurb` | `tinyint(1)` | Indicador refurb. |
+| `is_oem` | `tinyint(1)` | Indicador OEM. |
+| `is_bundle` | `tinyint(1)` | Indicador bundle. |
+
 ## Tablas `wp_compu_*`
 
 ### wp_compu_brands

--- a/server-mirror/compu-import-lego/includes/compu-media-helpers.php
+++ b/server-mirror/compu-import-lego/includes/compu-media-helpers.php
@@ -3,9 +3,9 @@ if (!function_exists('compu_image_from_row')) {
   function compu_image_from_row(array $r): ?string {
     $cands = [];
 
-    // 1) Llaves directas
-    foreach (['image','image_url','img','Imagen Principal','URL_IMAGEN','img_url'] as $k) {
-      if (!empty($r[$k])) $cands[] = (string)$r[$k];
+    // 1) Llaves directas (prioriza nombre canónico)
+    foreach (['image_url','image','img','Imagen Principal','URL_IMAGEN','img_url','picture'] as $k) {
+      if (!empty($r[$k])) { $cands[] = (string)$r[$k]; }
     }
     // 2) Arreglos comunes
     if (!empty($r['images']) && is_array($r['images']) && !empty($r['images'][0])) {
@@ -16,30 +16,26 @@ if (!function_exists('compu_image_from_row')) {
     }
 
     // 3) Fallback en HTML/description
-    foreach (['description','Descripción','desc','html','content'] as $hk) {
+    foreach (['description_html','description','Descripción','descripcion','desc','html','content'] as $hk) {
       if (!empty($r[$hk]) && is_string($r[$hk])) {
         $html = $r[$hk];
 
-        // a) <img ... src="...">
         if (preg_match('~<img[^>]+src=["\']([^"\']+)["\']~i', $html, $m) && !empty($m[1])) {
           $cands[] = $m[1];
         }
-        // b) primer URL de imagen en el texto
         if (preg_match('~\bhttps?:\/\/\S+\.(?:jpe?g|png|webp|gif)(?:\?\S*)?~i', $html, $m2) && !empty($m2[0])) {
           $cands[] = $m2[0];
         }
-        // c) URLs ftp de imagen
         if (preg_match('~\bftp:\/\/\S+\.(?:jpe?g|png|webp|gif)(?:\?\S*)?~i', $html, $m3) && !empty($m3[0])) {
           $cands[] = $m3[0];
         }
       }
     }
 
-    // Validación final (http/https/ftp + extensión de imagen)
     $re = '~^(https?|ftp)://.+\.(jpg|jpeg|png|webp|gif)(\?.*)?$~i';
     foreach ($cands as $u) {
       $u = trim((string)$u);
-      if ($u !== '' && preg_match($re, $u)) return $u;
+      if ($u !== '' && preg_match($re, $u)) { return $u; }
     }
     return null;
   }

--- a/server-mirror/compu-import-lego/includes/helpers/helpers-db.php
+++ b/server-mirror/compu-import-lego/includes/helpers/helpers-db.php
@@ -4,10 +4,23 @@ function compu_import_tables_ensure() {
   global $wpdb; $p=$wpdb->prefix;
   $wpdb->query("CREATE TABLE IF NOT EXISTS {$p}compu_lego_runs (id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, source VARCHAR(64), file_path TEXT, started_at DATETIME, finished_at DATETIME, status VARCHAR(32), ok_count INT DEFAULT 0, warn_count INT DEFAULT 0, error_count INT DEFAULT 0, notes TEXT) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
   $wpdb->query("CREATE TABLE IF NOT EXISTS {$p}compu_lego_log_items (id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, run_id BIGINT UNSIGNED NOT NULL, stage VARCHAR(64) NOT NULL, row_key VARCHAR(191), level VARCHAR(16) NOT NULL, message TEXT, raw_json LONGTEXT, created_at DATETIME, KEY run_id (run_id), KEY stage_row (stage,row_key)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-  $wpdb->query("CREATE TABLE IF NOT EXISTS {$p}compu_offers (id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, product_id BIGINT UNSIGNED NOT NULL, source VARCHAR(64) NOT NULL, supplier_sku VARCHAR(191), price_usd DECIMAL(12,4), exchange_rate DECIMAL(10,4), stock INT, offer_hash CHAR(32), valid_from DATETIME, created_at DATETIME, updated_at DATETIME, UNIQUE KEY uniq_offer (product_id, source)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+  $wpdb->query("CREATE TABLE IF NOT EXISTS {$p}compu_offers (id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY, product_id BIGINT UNSIGNED NULL, source VARCHAR(64) NOT NULL, supplier_sku VARCHAR(191) NOT NULL, cost_usd DECIMAL(12,4) NULL, exchange_rate DECIMAL(10,4) NULL, stock_total INT NULL, stock_main INT NULL, stock_tijuana INT NULL, stock_by_branch_json LONGTEXT NULL, currency CHAR(3) NULL, offer_hash CHAR(32) NULL, valid_from DATETIME NULL, created_at DATETIME NULL, updated_at DATETIME NULL, supplier VARCHAR(50) NULL, warehouse_id INT NULL, warehouse_code VARCHAR(50) NULL, lead_time_days INT NULL, is_refurb TINYINT(1) DEFAULT 0, is_oem TINYINT(1) DEFAULT 0, is_bundle TINYINT(1) DEFAULT 0, UNIQUE KEY uniq_supplier (supplier_sku, source), KEY product_source (product_id, source)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 }
 function compu_import_run_open($source='syscom', $file_path=null){ compu_import_tables_ensure(); global $wpdb; $wpdb->insert($wpdb->prefix.'compu_lego_runs',['source'=>$source,'file_path'=>$file_path,'started_at'=>compu_import_now(),'status'=>'running']); return (int)$wpdb->insert_id; }
 function compu_import_run_id_from_arg($run_id){ global $wpdb; if($run_id==='last' or !$run_id){$rid=(int)$wpdb->get_var("SELECT id FROM {$wpdb->prefix}compu_lego_runs ORDER BY id DESC LIMIT 1"); if(!$rid) throw new Exception('No hay runs previos. Ejecuta fetch/normalize primero.'); return $rid;} return (int)$run_id; }
 function compu_import_run_close($run_id,$status='completed',$ok=0,$warn=0,$err=0){ global $wpdb; $wpdb->update($wpdb->prefix.'compu_lego_runs',['finished_at'=>compu_import_now(),'status'=>$status,'ok_count'=>$ok,'warn_count'=>$warn,'error_count'=>$err],['id'=>$run_id]); }
 function compu_import_log($run_id,$stage,$level,$message,$raw=null,$row_key=null){ global $wpdb; $wpdb->insert($wpdb->prefix.'compu_lego_log_items',['run_id'=>$run_id,'stage'=>$stage,'row_key'=>$row_key,'level'=>$level,'message'=>$message,'raw_json'=>$raw?wp_json_encode($raw):null,'created_at'=>compu_import_now()]); if(defined('WP_CLI') && WP_CLI){ \WP_CLI::log("[".strtoupper($level)."][{$stage}] {$message}"); } }
-function compu_offers_upsert($product_id,$source,$offer){ global $wpdb; $t=$wpdb->prefix.'compu_offers'; $id=$wpdb->get_var($wpdb->prepare("SELECT id FROM {$t} WHERE product_id=%d AND source=%s",$product_id,$source)); $offer['updated_at']=compu_import_now(); if($id){ $wpdb->update($t,$offer,['id'=>$id]); return $id;} else { $offer['product_id']=$product_id; $offer['source']=$source; $offer['created_at']=compu_import_now(); $wpdb->insert($t,$offer); return (int)$wpdb->insert_id; } }
+function compu_offers_upsert($supplier_sku,$source,$offer){
+  global $wpdb; $t=$wpdb->prefix.'compu_offers';
+  $id=$wpdb->get_var($wpdb->prepare("SELECT id FROM {$t} WHERE supplier_sku=%s AND source=%s",$supplier_sku,$source));
+  $offer['updated_at']=compu_import_now();
+  if($id){
+    $wpdb->update($t,$offer,['id'=>$id]);
+    return (int)$id;
+  }
+  $offer['supplier_sku']=$supplier_sku;
+  $offer['source']=$source;
+  $offer['created_at']=compu_import_now();
+  $wpdb->insert($t,$offer);
+  return (int)$wpdb->insert_id;
+}

--- a/server-mirror/compu-import-lego/includes/stages/08-offers.php
+++ b/server-mirror/compu-import-lego/includes/stages/08-offers.php
@@ -1,132 +1,200 @@
 <?php
-if (!defined("COMP_RUN_STAGE")) { return; }
+if (!defined('COMP_RUN_STAGE')) { return; }
 if (!((defined('WP_CLI') && WP_CLI) || (defined('COMP_RUN_STAGE') && COMP_RUN_STAGE))) { return; }
+
+require_once dirname(__DIR__) . '/helpers/helpers-common.php';
+require_once dirname(__DIR__) . '/helpers/helpers-db.php';
+
 /**
- * Stage 08: Offers (upsert sobre wp_compu_offers con esquema real)
+ * Stage 08: Offers — persiste inventarios/costos canónicos en wp_compu_offers.
  */
 global $wpdb;
 
-$RUN_DIR = getenv('RUN_DIR'); $DEBUG = getenv('DEBUG') ?: 0;
+$RUN_DIR = getenv('RUN_DIR');
+$DEBUG   = getenv('DEBUG') ?: 0;
+$DRY     = (int) (getenv('DRY_RUN') ?: 0);
+$SOURCE  = getenv('OFFERS_SOURCE') ?: 'syscom';
 if (!$RUN_DIR) { fwrite(STDERR, "[08] Falta RUN_DIR\n"); return; }
-@mkdir("$RUN_DIR/logs", 0775, true); @mkdir("$RUN_DIR/final", 0775, true);
+@mkdir("$RUN_DIR/logs", 0775, true);
+@mkdir("$RUN_DIR/final", 0775, true);
 
 $LOG = fopen("$RUN_DIR/logs/stage08.log", "a");
 function SLOG08($m){ global $LOG,$DEBUG; $l="[".date('Y-m-d H:i:s')."] $m\n"; if($LOG)fwrite($LOG,$l); if($DEBUG)echo $l; }
 
-function compu_read_jsonl_08($p){
-  $fh=@fopen($p,"r"); if(!$fh)return[];
-  $a=[]; while(($l=fgets($fh))!==false){ $t=trim($l); if($t==='')continue; $o=json_decode($t,true); if(is_array($o))$a[]=$o; }
-  fclose($fh); return $a;
-}
-
-SLOG08("== Stage 08: offers ==");
-  // Helper: calcula existencias MAIN (todas menos Tijuana) y TJ
-  function _syscom_split_stock_08(array $r): array {
-    $cities_main = [
-      "Chihuahua","Cd. Juárez","Guadalajara","Los Mochis","Mérida","México Norte","México Sur",
-      "Monterrey","Puebla","Querétaro","Villahermosa","León","Hermosillo","San Luis Potosí",
-      "Torreón","Chihuahua CEDIS","Toluca","Stock Querétaro CEDIS","Stock Veracruz","Stock Tepotzotlan",
-      "Stock Cancun","Stock Culiacan","Stock Monterrey Centro"
-    ];
-    $toInt=function($v){ return is_numeric($v)? max(0,intval($v)) : 0; };
-    $tj = $toInt($r["Tijuana"] ?? 0);
-    $main=0; foreach($cities_main as $c){ $main += $toInt($r[$c] ?? 0); }
-    return [$main,$tj];
-  }
-SLOG08("ENTER stage 08");
 $src = file_exists("$RUN_DIR/resolved.jsonl") ? "$RUN_DIR/resolved.jsonl" : "$RUN_DIR/validated.jsonl";
-$rows = $src ? compu_read_jsonl_08($src) : array();
-if (empty($rows)) { SLOG08("No hay datos"); return; }
+$rows = $src ? compu_import_read_jsonl($src) : [];
+if (empty($rows)) { SLOG08("No hay datos en resolved/validated"); return; }
 
-$table = $wpdb->prefix."compu_offers"; // esquema real
-$out=fopen("$RUN_DIR/final/offers_upserted.csv","w");
-fputcsv($out,["sku","stock","cost_usd","fx","action"]);
+$csv = fopen("$RUN_DIR/final/offers_upserted.csv","w");
+fputcsv($csv,['sku','stock_total','cost_usd','exchange_rate','action'], ',', '"', '\\');
 
-$ins=0;$upd=0;$unch=0;$err=0;
+$inserted=0; $updated=0; $unchanged=0; $errors=0;
 
-$skipped_no_pid=0;
-foreach($rows as $r){
-  // sku fuente (modelo)
-  $sku = $r['sku'] ?? ($r['model'] ?? null);
-  if(!$sku){ $err++; fputcsv($out,["",0,0,0,"error"]); SLOG08("ROW sin sku/model"); continue; }
-
-  // mapa campos
-  $cost = null; foreach(['Su Precio','su_precio','cost_base','precio_usd'] as $k){ if(isset($r[$k]) && is_numeric($r[$k])){$cost=floatval($r[$k]);break;} }
-  $fx   = null; foreach(['Tipo de Cambio','tipo_cambio','exchange_rate'] as $k){ if(isset($r[$k]) && is_numeric($r[$k])){$fx=floatval($r[$k]);break;} }
-  $stk  = null; foreach(['Existencias','existencias','stock'] as $k){ if(isset($r[$k]) && is_numeric($r[$k])){$stk=intval($r[$k]);break;} }
-  if($cost===null)$cost=0.0; if($fx===null)$fx=0.0; if($stk===null)$stk=0;
-
-  // intentamos mapear al product_id por SKU de Woo (si existe)
-  $pid = (function_exists('wc_get_product_id_by_sku')? wc_get_product_id_by_sku($sku) : 0);
-  $warehouse_id = 15; $supplier = "SYSCOM"; $currency = "USD";
-  $product_id = intval($pid ?: 0); $supplier_sku = $sku;
-  if($product_id<=0){ $err++; $act="error"; SLOG08("NOPROD sku=".$sku); fputcsv($out,[$sku,0,$supplier,15,"MAIN",0,0,$currency,$act]); continue; }
-  $warehouse_id = 15; $supplier = "SYSCOM"; $currency = "USD";
-  $product_id = intval($pid ?: 0); $supplier_sku = $sku;
-  $warehouse_id = 15; $supplier = "SYSCOM"; $currency = "USD";
-  $product_id = intval($pid ?: 0); $supplier_sku = $sku;
-  $pid = intval($pid) ?: null;
-
-  // columnas reales del schema
-  // - supplier_sku := sku origen
-  // - price_cost   := costo (lo tratamos como USD)
-  // - currency     := 'USD' si cost>0
-  // - stock        := stk
-  // - last_synced_at := now
-  // - product_id   := si se pudo resolver
-  $now = current_time('mysql');
-  $currency = ($cost > 0) ? 'USD' : null;
-
-  // ¿existe ya una oferta con este supplier_sku?
-  $row = $wpdb->get_row($wpdb->prepare("SELECT id, price_cost, currency, stock, product_id FROM $table WHERE supplier_sku=%s",$sku), ARRAY_A);
-
-  if($row){
-    $changed = (abs(floatval($row['price_cost']) - $cost) > 0.000001)
-            || (($row['currency'] ?? null) !== $currency)
-            || (intval($row['stock']) !== $stk)
-            || (($pid !== null) && (intval($row['product_id']) !== $pid));
-
-    $data = [
-      'price_cost'    => $cost,
-      'currency'      => $currency,
-      'stock'         => $stk,
-      'last_synced_at'=> $now,
-    ];
-    $fmt  = ['%f','%s','%d','%s'];
-
-    if ($pid !== null) { $data['product_id'] = $pid; $fmt[] = '%d'; }
-
-    $ok = $wpdb->update($table, $data, ['supplier_sku'=>$sku], $fmt, ['%s']);
-    if($ok===false){ $err++; $act='error'; SLOG08("DBERR UPDATE sku=$sku err=".$wpdb->last_error); }
-    else { $act = $changed ? 'updated' : 'unchanged'; $changed ? $upd++ : $unch++; }
-  } else {
-    $data = [
-      'supplier_sku'  => $sku,
-      'price_cost'    => $cost,
-      'currency'      => $currency,
-      'stock'         => $stk,
-      'last_synced_at'=> $now,
-      // opcionales con defaults
-      'supplier'      => 'default',
-      'warehouse_id'  => null,
-      'warehouse_code'=> '',
-      'lead_time_days'=> 0,
-      'is_refurb'     => 0,
-      'is_oem'        => 0,
-      'is_bundle'     => 0,
-    ];
-    $fmt = ['%s','%f','%s','%d','%s','%s','%d','%s','%d','%d','%d','%d'];
-
-    if ($pid !== null) { $data['product_id'] = $pid; $fmt[] = '%d'; }
-
-    $ok = $wpdb->insert($table, $data, $fmt);
-    if($ok===false){ $err++; $act='error'; SLOG08("DBERR INSERT sku=$sku err=".$wpdb->last_error); }
-    else { $ins++; $act='inserted'; }
+foreach ($rows as $row) {
+  if (!is_array($row)) { continue; }
+  $sku = stage08_first($row, ['sku','supplier_sku','model','codigo','code']);
+  if (!$sku) {
+    $errors++; fputcsv($csv,['',0,0,0,'error']); SLOG08('ROW sin sku');
+    continue;
   }
 
-  // CSV con la misma forma que tenías
-  fputcsv($out,[$sku,$stk,$cost,$fx,$act]);
+  $offer = stage08_build_offer_payload($row);
+  $offer['supplier'] = $offer['supplier'] ?? 'default';
+
+  $product_id = 0;
+  if (function_exists('wc_get_product_id_by_sku')) {
+    $product_id = (int) wc_get_product_id_by_sku($sku);
+  }
+  if ($product_id > 0) {
+    $offer['product_id'] = $product_id;
+  } else {
+    $offer['product_id'] = null;
+  }
+
+  $action = 'dry_run';
+  if ($DRY) {
+    $action = 'dry_run';
+  } else {
+    try {
+      $existing = $wpdb->get_row(
+        $wpdb->prepare("SELECT id, cost_usd, exchange_rate, stock_total, stock_main, stock_tijuana, stock_by_branch_json, product_id FROM {$wpdb->prefix}compu_offers WHERE supplier_sku=%s AND source=%s", $sku, $SOURCE),
+        ARRAY_A
+      );
+    } catch (\Exception $e) {
+      $existing = null;
+    }
+
+    $jsonBranches = $offer['stock_by_branch_json'] ?? null;
+    if (is_array($jsonBranches)) {
+      $offer['stock_by_branch_json'] = wp_json_encode($jsonBranches, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
+    }
+
+    $changed = true;
+    if ($existing) {
+      $changed = stage08_has_changed($existing, $offer);
+    }
+
+    if (!$changed) {
+      $unchanged++;
+      $action = 'unchanged';
+    } else {
+      if (!empty($jsonBranches) && is_array($jsonBranches)) {
+        $offer['stock_by_branch_json'] = wp_json_encode($jsonBranches, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
+      }
+      $id = compu_offers_upsert($sku, $SOURCE, $offer);
+      if ($id) {
+        if ($existing) { $updated++; $action = 'updated'; }
+        else { $inserted++; $action = 'inserted'; }
+      } else {
+        $errors++; $action = 'error';
+        SLOG08("DBERR sku=$sku: ".$wpdb->last_error);
+      }
+    }
+  }
+
+  fputcsv($csv,[$sku,$offer['stock_total'] ?? 0,$offer['cost_usd'] ?? 0,$offer['exchange_rate'] ?? 0,$action], ',', '"', '\\');
 }
 
-SLOG08("Insertados=$ins Actualizados=$upd SinCambio=$unch Errores=$err");
-SLOG08("LEAVE stage 08");
+fclose($csv);
+SLOG08("Insertados=$inserted Actualizados=$updated SinCambio=$unchanged Errores=$errors");
+
+function stage08_first(array $row, array $keys){
+  foreach ($keys as $k) {
+    if (isset($row[$k]) && trim((string)$row[$k]) !== '') {
+      return trim((string)$row[$k]);
+    }
+  }
+  return null;
+}
+
+function stage08_build_offer_payload(array $row): array {
+  $cost = stage08_number($row, ['cost_usd','price_usd','su_precio','precio','precio_usd']);
+  $fx   = stage08_number($row, ['exchange_rate','fx','tipo_cambio','exchange']);
+  $stockTotal = stage08_int($row, ['stock_total','stock','existencias']);
+  $stockMain  = stage08_int($row, ['stock_main','stock_a15','stock_others']);
+  $stockTj    = stage08_int($row, ['stock_tijuana','stock_a15_tj']);
+
+  $branches = null;
+  if (!empty($row['stock_by_branch']) && is_array($row['stock_by_branch'])) {
+    $branches = $row['stock_by_branch'];
+  } elseif (!empty($row['stocks_by_branch']) && is_array($row['stocks_by_branch'])) {
+    $branches = $row['stocks_by_branch'];
+  }
+  if ($branches) {
+    $stockTotal = (int) array_sum(array_map('intval', $branches));
+    $stockTj = 0;
+    foreach ($branches as $name => $qty) {
+      if (stripos((string)$name, 'tijuana') !== false || stripos((string)$name, 'tj') !== false) {
+        $stockTj += (int)$qty;
+      }
+    }
+    $stockMain = max(0, $stockTotal - $stockTj);
+  }
+
+  $currency = $cost > 0 ? 'USD' : null;
+
+  $payload = [
+    'cost_usd'             => $cost,
+    'exchange_rate'        => $fx,
+    'stock_total'          => $stockTotal,
+    'stock_main'           => $stockMain,
+    'stock_tijuana'        => $stockTj,
+    'stock_by_branch_json' => $branches,
+    'currency'             => $currency,
+  ];
+  if (isset($row['supplier'])) { $payload['supplier'] = $row['supplier']; }
+  if (isset($row['warehouse_id'])) { $payload['warehouse_id'] = (int)$row['warehouse_id']; }
+  if (isset($row['warehouse_code'])) { $payload['warehouse_code'] = (string)$row['warehouse_code']; }
+  if (isset($row['lead_time_days'])) { $payload['lead_time_days'] = (int)$row['lead_time_days']; }
+  if (isset($row['is_refurb'])) { $payload['is_refurb'] = (int)$row['is_refurb']; }
+  if (isset($row['is_oem'])) { $payload['is_oem'] = (int)$row['is_oem']; }
+  if (isset($row['is_bundle'])) { $payload['is_bundle'] = (int)$row['is_bundle']; }
+  return $payload;
+}
+
+function stage08_number(array $row, array $keys): ?float {
+  foreach ($keys as $key) {
+    if (!isset($row[$key])) { continue; }
+    $val = trim((string)$row[$key]);
+    if ($val === '') { continue; }
+    $val = str_replace([','], '.', $val);
+    $val = preg_replace('/[^0-9\.-]/','', $val);
+    if ($val === '' || $val === '-' || $val === '.') { continue; }
+    return (float)$val;
+  }
+  return null;
+}
+
+function stage08_int(array $row, array $keys): ?int {
+  foreach ($keys as $key) {
+    if (!isset($row[$key])) { continue; }
+    $val = trim((string)$row[$key]);
+    if ($val === '') { continue; }
+    $val = preg_replace('/[^0-9\-]/','', $val);
+    if ($val === '' || $val === '-') { continue; }
+    return (int)$val;
+  }
+  return null;
+}
+
+function stage08_has_changed(array $existing, array $offer): bool {
+  $fields = ['cost_usd','exchange_rate','stock_total','stock_main','stock_tijuana'];
+  foreach ($fields as $field) {
+    $old = $existing[$field] ?? null;
+    $new = $offer[$field] ?? null;
+    if ($old === null && $new === null) { continue; }
+    if ($field === 'exchange_rate' || $field === 'cost_usd') {
+      if (abs(floatval($old) - floatval($new)) > 0.0001) { return true; }
+    } else {
+      if ((int)$old !== (int)$new) { return true; }
+    }
+  }
+  $oldJson = $existing['stock_by_branch_json'] ?? null;
+  $newJson = $offer['stock_by_branch_json'] ?? null;
+  if (is_array($newJson)) { $newJson = wp_json_encode($newJson); }
+  if ($oldJson != $newJson) { return true; }
+  if (!empty($offer['product_id']) && (int)$offer['product_id'] !== (int)($existing['product_id'] ?? 0)) {
+    return true;
+  }
+  return false;
+}

--- a/server-mirror/compu-import-lego/includes/stages/09-pricing.php
+++ b/server-mirror/compu-import-lego/includes/stages/09-pricing.php
@@ -1,77 +1,100 @@
 <?php
-if (!defined("COMP_RUN_STAGE")) { return; }
+if (!defined('COMP_RUN_STAGE')) { return; }
 if (!((defined('WP_CLI') && WP_CLI) || (defined('COMP_RUN_STAGE') && COMP_RUN_STAGE))) { return; }
+
 /**
- * Stage 09: Pricing Woo (lower-only)
+ * Stage 09: Pricing Woo (usa columnas canónicas de compu_offers).
  */
 global $wpdb;
 
-$RUN_DIR = getenv('RUN_DIR'); $DEBUG = getenv('DEBUG') ?: 0;
+$RUN_DIR = getenv('RUN_DIR');
+$DEBUG   = getenv('DEBUG') ?: 0;
 if (!$RUN_DIR) { fwrite(STDERR, "[09] Falta RUN_DIR\n"); return; }
-@mkdir("$RUN_DIR/logs", 0775, true); @mkdir("$RUN_DIR/final", 0775, true);
+@mkdir("$RUN_DIR/logs", 0775, true);
+@mkdir("$RUN_DIR/final", 0775, true);
 $LOG = fopen("$RUN_DIR/logs/stage09.log", "a");
 function SLOG09($m){ global $LOG,$DEBUG; $l="[".date('Y-m-d H:i:s')."] $m\n"; if($LOG)fwrite($LOG,$l); if($DEBUG)echo $l; }
 
 if (!function_exists('wc_get_product_id_by_sku')) { SLOG09("WooCommerce no cargado; abortando stage 09"); return; }
 
-function compu_round_0_5_9_down_09($price){
-  $p=floor($price); $last=$p%10;
-  if($last>=9) $p-=$last-9; elseif($last>=5) $p-=$last-5; else $p-=$last;
-  return max($p,0);
-}
-function compu_current_eff_price_09($p){
-  $reg=floatval($p->get_regular_price()); $sal=$p->get_sale_price();
-  $salv=(is_numeric($sal)&&floatval($sal)>0)?floatval($sal):null;
-  return ($salv!==null && $salv<$reg) ? $salv : $reg;
-}
-
-$IVA_DEFAULT = getenv('IVA_DEFAULT'); $IVA = is_numeric($IVA_DEFAULT) ? floatval($IVA_DEFAULT) : 16.0;
+$IVA_DEFAULT = getenv('IVA_DEFAULT');
+$IVA = is_numeric($IVA_DEFAULT) ? floatval($IVA_DEFAULT) : 16.0;
 $table = $wpdb->prefix."compu_offers";
 
-$csv = fopen("$RUN_DIR/final/woo_synced.csv","w");
-$csvd= fopen("$RUN_DIR/final/price_dropped.csv","w");
-$csvk= fopen("$RUN_DIR/final/unchanged.csv","w");
-$csve= fopen("$RUN_DIR/final/errors.csv","w");
-fputcsv($csv,["sku","before","target","action"]);
-fputcsv($csvd,["sku","from","to"]);
-fputcsv($csvk,["sku","price"]);
-fputcsv($csve,["sku","reason"]);
+$csvSync = fopen("$RUN_DIR/final/woo_synced.csv","w");
+$csvDrop = fopen("$RUN_DIR/final/price_dropped.csv","w");
+$csvKeep = fopen("$RUN_DIR/final/unchanged.csv","w");
+$csvErr  = fopen("$RUN_DIR/final/errors.csv","w");
+fputcsv($csvSync,["sku","before","target","action"], ',', '"', '\\');
+fputcsv($csvDrop,["sku","from","to"], ',', '"', '\\');
+fputcsv($csvKeep,["sku","price"], ',', '"', '\\');
+fputcsv($csvErr,["sku","reason"], ',', '"', '\\');
 
 $ok=0;$drop=0;$keep=0;$err=0;
 
-$offers = $wpdb->get_results("SELECT sku,cost_base,exchange_rate,stock FROM $table", ARRAY_A);
-foreach($offers as $o){
-  $sku=$o['sku']; if(!$sku)continue;
-  $pid=wc_get_product_id_by_sku($sku); if(!$pid){fputcsv($csve,[$sku,"product_not_found"]);$err++;continue;}
-  $p=wc_get_product($pid); if(!$p){fputcsv($csve,[$sku,"wc_get_product_failed"]);$err++;continue;}
+$offers = $wpdb->get_results("SELECT supplier_sku, cost_usd, exchange_rate, stock_total FROM {$table}", ARRAY_A);
+foreach ($offers as $offer) {
+  $sku = $offer['supplier_sku'] ?? null;
+  if (!$sku) { continue; }
 
-  $base_mxn=floatval($o['cost_base'])*max(0.0,floatval($o['exchange_rate']));
-  $margin=0.15; // TODO: conectar a tabla real si nos la das
-  $target=compu_round_0_5_9_down_09($base_mxn*(1+$margin)*(1+$IVA/100.0));
+  $pid = wc_get_product_id_by_sku($sku);
+  if (!$pid) { fputcsv($csvErr,[$sku,'product_not_found']); $err++; continue; }
+  $product = wc_get_product($pid);
+  if (!$product) { fputcsv($csvErr,[$sku,'wc_get_product_failed']); $err++; continue; }
 
-  $before=compu_current_eff_price_09($p);
-  $did=false;
+  $costUsd = (float) ($offer['cost_usd'] ?? 0);
+  $fx      = (float) ($offer['exchange_rate'] ?? 0);
+  $stock   = (int)   ($offer['stock_total'] ?? 0);
+  if ($costUsd <= 0 || $fx <= 0) { $fx = max($fx, 1.0); }
 
-  if($before<=0 || $target<$before){
-    $p->set_regular_price($target);
-    $sal=$p->get_sale_price(); if(!$sal || floatval($sal)>=$target){ $p->set_sale_price(''); }
-    $did=true;
+  $baseMxn = $costUsd * $fx;
+  $margin  = 0.15; // TODO: enlazar con tabla de márgenes
+  $target  = stage09_round_margin($baseMxn * (1+$margin) * (1 + $IVA/100));
+
+  $before = stage09_current_price($product);
+  $didUpdate = false;
+  if ($before <= 0 || $target < $before) {
+    $product->set_regular_price($target);
+    $sale = $product->get_sale_price();
+    if (!$sale || floatval($sale) >= $target) {
+      $product->set_sale_price('');
+    }
+    $didUpdate = true;
   }
 
-  // Stock (sin ocultar)
-  $stk=intval($o['stock']);
-  $p->set_manage_stock(true);
-  $p->set_stock_quantity(max(0,$stk));
-  $p->set_stock_status($stk>0 ? 'instock' : 'outofstock');
+  $product->set_manage_stock(true);
+  $product->set_stock_quantity(max(0,$stock));
+  $product->set_stock_status($stock>0 ? 'instock' : 'outofstock');
 
-  if($did || true){ $p->save(); }
+  $product->save();
 
-  if($did){
-    fputcsv($csv,[$sku,$before,$target,"lower_or_set"]);
-    if($before>0 && $target<$before){ fputcsv($csvd,[$sku,$before,$target]); $drop++; }
+  if ($didUpdate) {
+    fputcsv($csvSync,[$sku,$before,$target,'lower_or_set'], ',', '"', '\\');
+    if ($before>0 && $target<$before) { fputcsv($csvDrop,[$sku,$before,$target], ',', '"', '\\'); $drop++; }
     $ok++;
   } else {
-    fputcsv($csvk,[$sku,$before]); $keep++;
+    fputcsv($csvKeep,[$sku,$before], ',', '"', '\\');
+    $keep++;
   }
 }
+
 SLOG09("Pricing: ok=$ok drop=$drop keep=$keep err=$err");
+
+function stage09_current_price($product){
+  $regular = (float) $product->get_regular_price();
+  $sale    = $product->get_sale_price();
+  if ($sale !== '') {
+    $saleVal = (float)$sale;
+    if ($saleVal > 0 && $saleVal < $regular) { return $saleVal; }
+  }
+  return $regular;
+}
+
+function stage09_round_margin($price){
+  $p = floor($price);
+  $last = $p % 10;
+  if ($last >= 9) { $p -= $last - 9; }
+  elseif ($last >= 5) { $p -= $last - 5; }
+  else { $p -= $last; }
+  return max($p, 0);
+}

--- a/tests/canonical_pipeline_test.php
+++ b/tests/canonical_pipeline_test.php
@@ -1,0 +1,208 @@
+<?php
+declare(strict_types=1);
+
+// --- WordPress stubs ----------------------------------------------------
+if (!defined('COMP_RUN_STAGE')) { define('COMP_RUN_STAGE', true); }
+if (!defined('ABSPATH')) { define('ABSPATH', __DIR__.'/..'); }
+if (!defined('WPINC')) { define('WPINC', 'wp-includes'); }
+if (!defined('COMPU_IMPORT_UPLOAD_SUBDIR')) { define('COMPU_IMPORT_UPLOAD_SUBDIR', 'runs'); }
+if (!defined('ARRAY_A')) { define('ARRAY_A', 'ARRAY_A'); }
+
+function trailingslashit($path){ return rtrim($path, '/').'/' ; }
+function wp_json_encode($data, $options = 0){ return json_encode($data, $options); }
+function wp_upload_dir(){ global $COMP_TEST_BASEDIR; return ['basedir'=>$COMP_TEST_BASEDIR, 'baseurl'=>'http://example.com/uploads']; }
+function wp_mkdir_p($dir){ if (!is_dir($dir)) { mkdir($dir, 0775, true); } }
+function current_time($type='mysql'){ return $type === 'mysql' ? '2025-10-05 00:00:00' : time(); }
+function remove_accents($string){ return $string; }
+function sanitize_title($title){ return preg_replace('/[^a-z0-9]+/i','-', strtolower($title)); }
+function wp_strip_all_tags($text){ return strip_tags($text); }
+class WP_CLI { public static function error($msg){ throw new RuntimeException($msg); } public static function log($msg){} }
+
+// --- WooCommerce stubs ---------------------------------------------------
+class FakeProduct {
+  private $sku;
+  private $regular;
+  private $sale;
+  private $stockQty;
+  private $stockStatus;
+  private $manageStock = false;
+
+  public function __construct(string $sku, float $regular = 1000.0, ?float $sale = null){
+    $this->sku = $sku;
+    $this->regular = $regular;
+    $this->sale = $sale;
+    $this->stockQty = 0;
+    $this->stockStatus = 'instock';
+  }
+  public function get_regular_price(){ return $this->regular; }
+  public function get_sale_price(){ return $this->sale === null ? '' : (string)$this->sale; }
+  public function set_regular_price($price){ $this->regular = (float)$price; }
+  public function set_sale_price($price){ $this->sale = ($price === '' ? null : (float)$price); }
+  public function set_manage_stock($flag){ $this->manageStock = (bool)$flag; }
+  public function set_stock_quantity($qty){ $this->stockQty = (int)$qty; }
+  public function set_stock_status($status){ $this->stockStatus = $status; }
+  public function save(){ /* no-op */ }
+  public function snapshot(): array {
+    return [
+      'regular_price' => $this->regular,
+      'sale_price'    => $this->sale,
+      'stock_qty'     => $this->stockQty,
+      'stock_status'  => $this->stockStatus,
+      'manage_stock'  => $this->manageStock,
+    ];
+  }
+}
+
+$FAKE_PRODUCTS = [];
+$FAKE_SKU_TO_ID = [];
+function wc_get_product_id_by_sku($sku){
+  global $FAKE_SKU_TO_ID;
+  return $FAKE_SKU_TO_ID[$sku] ?? 0;
+}
+function wc_get_product($id){
+  global $FAKE_PRODUCTS;
+  return $FAKE_PRODUCTS[$id] ?? null;
+}
+
+// --- Fake wpdb -----------------------------------------------------------
+class FakeWpdb {
+  public $prefix = 'wp_';
+  public $last_error = '';
+  public $insert_id = 0;
+  private $offersBySource = [];
+  private $offersById = [];
+
+  public function query($sql){ return true; }
+  public function prepare($query, ...$args){ return ['query'=>$query,'args'=>$args]; }
+
+  public function get_var($prepared){
+    if (is_array($prepared) && strpos($prepared['query'],'compu_offers') !== false) {
+      $args = $prepared['args'];
+      $sku = $args[0] ?? null;
+      $source = $args[1] ?? 'syscom';
+      if ($sku && isset($this->offersBySource[$source][$sku])) {
+        return $this->offersBySource[$source][$sku]['id'];
+      }
+    }
+    return null;
+  }
+
+  public function get_row($prepared, $output=ARRAY_A){
+    if (is_array($prepared) && strpos($prepared['query'],'compu_offers') !== false) {
+      $args = $prepared['args'];
+      $sku = $args[0] ?? null;
+      $source = $args[1] ?? 'syscom';
+      if ($sku && isset($this->offersBySource[$source][$sku])) {
+        return $this->offersBySource[$source][$sku];
+      }
+    }
+    return null;
+  }
+
+  public function update($table, $data, $where){
+    if ($table !== $this->prefix.'compu_offers') { return true; }
+    $id = $where['id'] ?? null;
+    if (!$id || !isset($this->offersById[$id])) { return false; }
+    $record =& $this->offersById[$id];
+    foreach ($data as $k => $v) { $record[$k] = $v; }
+    return true;
+  }
+
+  public function insert($table, $data){
+    if ($table !== $this->prefix.'compu_offers') { return true; }
+    $this->insert_id++;
+    $data['id'] = $this->insert_id;
+    $source = $data['source'] ?? 'syscom';
+    $sku    = $data['supplier_sku'];
+    $this->offersBySource[$source][$sku] = $data;
+    $this->offersById[$this->insert_id]  =& $this->offersBySource[$source][$sku];
+    return true;
+  }
+
+  public function get_results($query, $output=ARRAY_A){
+    if (strpos($query,'compu_offers') === false) { return []; }
+    $out = [];
+    foreach ($this->offersBySource as $source => $offers) {
+      foreach ($offers as $sku => $data) {
+        $out[] = [
+          'supplier_sku' => $sku,
+          'cost_usd' => $data['cost_usd'] ?? null,
+          'exchange_rate' => $data['exchange_rate'] ?? null,
+          'stock_total' => $data['stock_total'] ?? null,
+        ];
+      }
+    }
+    return $out;
+  }
+
+  public function get_offer(string $source, string $sku): ?array {
+    return $this->offersBySource[$source][$sku] ?? null;
+  }
+}
+
+// --- Preparar entorno temporal -----------------------------------------
+$COMP_TEST_BASEDIR = sys_get_temp_dir().'/compu_stage_pipeline_'.uniqid();
+wp_mkdir_p($COMP_TEST_BASEDIR.'/runs');
+$runDir = $COMP_TEST_BASEDIR.'/runs/run-1';
+wp_mkdir_p($runDir);
+
+$wpdb = new FakeWpdb();
+
+$sourceCsv = $runDir.'/source.csv';
+file_put_contents($sourceCsv, implode("\n", [
+  'Modelo,Marca,Título,Su Precio,Tipo de Cambio,Existencias,Tijuana,Chihuahua,Descripción,Imagen Principal',
+  "ABC123,ACME,\"Producto Demo\",10.00,17.50,5,2,3,\"<p>Excelente equipo</p>\",\"http://example.com/img.jpg\""
+]));
+
+// --- Ejecutar Stage 02 ---------------------------------------------------
+require_once __DIR__.'/../server-mirror/compu-import-lego/includes/stages/02-normalize.php';
+
+$stage02 = new Compu_Stage_Normalize();
+$stage02->run(['run-id' => 1]);
+
+$normalizedPath = $runDir.'/normalized.jsonl';
+if (!file_exists($normalizedPath)) { throw new RuntimeException('No se generó normalized.jsonl'); }
+$lines = file($normalizedPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+if (!$lines) { throw new RuntimeException('normalized.jsonl vacío'); }
+$row02 = json_decode($lines[0], true);
+assert($row02 !== null);
+
+$expectedFields = ['cost_usd','exchange_rate','stock_total','stock_main','stock_tijuana','price_usd','stock'];
+foreach ($expectedFields as $field) {
+  if (!array_key_exists($field, $row02)) {
+    throw new RuntimeException("Campo faltante en Stage02: {$field}");
+  }
+}
+
+if (abs($row02['cost_usd'] - 10.0) > 0.001) { throw new RuntimeException('cost_usd incorrecto'); }
+if (abs($row02['exchange_rate'] - 17.5) > 0.001) { throw new RuntimeException('exchange_rate incorrecto'); }
+if ((int)$row02['stock_total'] !== 5) { throw new RuntimeException('stock_total incorrecto'); }
+if ((int)$row02['stock_main'] !== 3) { throw new RuntimeException('stock_main incorrecto'); }
+if ((int)$row02['stock_tijuana'] !== 2) { throw new RuntimeException('stock_tijuana incorrecto'); }
+
+// Simular que resolved.jsonl es igual al normalized
+copy($normalizedPath, $runDir.'/resolved.jsonl');
+
+// --- Ejecutar Stage 08 ---------------------------------------------------
+$wpdb = new FakeWpdb();
+putenv('RUN_DIR='.$runDir);
+putenv('DRY_RUN=0');
+putenv('OFFERS_SOURCE=syscom');
+require __DIR__.'/../server-mirror/compu-import-lego/includes/stages/08-offers.php';
+
+$offerRow = $wpdb->get_offer('syscom', 'ABC123');
+if (!$offerRow) { throw new RuntimeException('Stage08 no generó oferta para ABC123'); }
+if (abs($offerRow['cost_usd'] - 10.0) > 0.001) { throw new RuntimeException('Stage08 cost_usd diferente'); }
+if (abs($offerRow['exchange_rate'] - 17.5) > 0.001) { throw new RuntimeException('Stage08 exchange_rate diferente'); }
+if ((int)$offerRow['stock_total'] !== 5) { throw new RuntimeException('Stage08 stock_total diferente'); }
+
+// --- Preparar Woo stub y ejecutar Stage 09 -------------------------------
+$FAKE_SKU_TO_ID['ABC123'] = 101;
+$FAKE_PRODUCTS[101] = new FakeProduct('ABC123', 999.0, null);
+require __DIR__.'/../server-mirror/compu-import-lego/includes/stages/09-pricing.php';
+
+$snapshot = $FAKE_PRODUCTS[101]->snapshot();
+if ($snapshot['regular_price'] >= 999.0) { throw new RuntimeException('Stage09 no actualizó el precio'); }
+if ($snapshot['stock_qty'] !== 5) { throw new RuntimeException('Stage09 no propagó stock_total'); }
+
+echo "OK: pipeline canónico operando con cost_usd/exchange_rate/stock_total\n";


### PR DESCRIPTION
## Summary
- refactor stage 02 to emit the new canonical dictionary while keeping legacy aliases
- simplify stage 06, media helper, and pricing/offers stages to consume canonical fields and align with the updated compu_offers table
- add the compu_offers migration, end-to-end pipeline test, and documentation for the canonical schema

## Testing
- php tests/canonical_pipeline_test.php

------
https://chatgpt.com/codex/tasks/task_b_68e1e12f0c948320839e66a57241dcd2