### PR TITLE
Refactor stage 09 pricing runner and share run dir helper

### DIFF
--- a/server-mirror/compu-import-lego/includes/helpers/helpers-common.php
+++ b/server-mirror/compu-import-lego/includes/helpers/helpers-common.php
@@ -13,3 +13,43 @@ function compu_import_row_hash($arr){ ksort($arr); return md5(json_encode($arr, 
 function compu_import_read_jsonl($path){ $o=[]; $fh=@fopen($path,'r'); if(!$fh) return $o; while(($l=fgets($fh))!==false){$l=trim($l); if($l==='')continue; $o[] = json_decode($l,true);} fclose($fh); return $o; }
 function compu_import_append_jsonl($path,$row){ $fh=fopen($path,'a'); fwrite($fh, json_encode($row, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES)."\n"); fclose($fh); }
 function compu_import_slug($s){ $s = remove_accents($s); $s=strtolower(preg_replace('/[^a-z0-9]+/i','-',$s)); return trim($s,'-'); }
+
+if (!function_exists('compu_import_resolve_run_dir')) {
+  /**
+   * Resuelve el directorio base de ejecución para los stages.
+   * Prioridad: opciones explícitas (run_dir, runDir, dir, path) antes de variables de entorno (RUN_DIR, RUN_PATH).
+   *
+   * @param array<string,mixed> $opts
+   */
+  function compu_import_resolve_run_dir(array $opts = []): string {
+    $candidates = [];
+
+    foreach (['run_dir', 'runDir', 'dir', 'path'] as $key) {
+      if (!array_key_exists($key, $opts)) {
+        continue;
+      }
+      $value = trim((string) $opts[$key]);
+      if ($value === '') {
+        continue;
+      }
+      $candidates[] = $value;
+    }
+
+    foreach (['RUN_DIR', 'RUN_PATH'] as $envKey) {
+      $envValue = getenv($envKey);
+      if ($envValue === false || $envValue === '') {
+        continue;
+      }
+      $candidates[] = trim((string) $envValue);
+    }
+
+    foreach ($candidates as $candidate) {
+      if ($candidate === '') {
+        continue;
+      }
+      return rtrim($candidate, '/');
+    }
+
+    return '';
+  }
+}

--- a/server-mirror/compu-import-lego/includes/stages/08-offers.php
+++ b/server-mirror/compu-import-lego/includes/stages/08-offers.php
@@ -10,7 +10,7 @@ require_once dirname(__DIR__) . '/helpers/helpers-db.php';
  */
 global $wpdb;
 
-$RUN_DIR = getenv('RUN_DIR');
+$RUN_DIR = compu_import_resolve_run_dir();
 $DEBUG   = getenv('DEBUG') ?: 0;
 $DRY     = (int) (getenv('DRY_RUN') ?: 0);
 $SOURCE  = getenv('OFFERS_SOURCE') ?: 'syscom';

--- a/server-mirror/compu-import-lego/includes/stages/09-pricing.php
+++ b/server-mirror/compu-import-lego/includes/stages/09-pricing.php
@@ -1,100 +1,336 @@
 <?php
 if (!defined('COMP_RUN_STAGE')) { return; }
-if (!((defined('WP_CLI') && WP_CLI) || (defined('COMP_RUN_STAGE') && COMP_RUN_STAGE))) { return; }
 
-/**
- * Stage 09: Pricing Woo (usa columnas canónicas de compu_offers).
- */
-global $wpdb;
+require_once dirname(__DIR__) . '/helpers/helpers-common.php';
 
-$RUN_DIR = getenv('RUN_DIR');
-$DEBUG   = getenv('DEBUG') ?: 0;
-if (!$RUN_DIR) { fwrite(STDERR, "[09] Falta RUN_DIR\n"); return; }
-@mkdir("$RUN_DIR/logs", 0775, true);
-@mkdir("$RUN_DIR/final", 0775, true);
-$LOG = fopen("$RUN_DIR/logs/stage09.log", "a");
-function SLOG09($m){ global $LOG,$DEBUG; $l="[".date('Y-m-d H:i:s')."] $m\n"; if($LOG)fwrite($LOG,$l); if($DEBUG)echo $l; }
-
-if (!function_exists('wc_get_product_id_by_sku')) { SLOG09("WooCommerce no cargado; abortando stage 09"); return; }
-
-$IVA_DEFAULT = getenv('IVA_DEFAULT');
-$IVA = is_numeric($IVA_DEFAULT) ? floatval($IVA_DEFAULT) : 16.0;
-$table = $wpdb->prefix."compu_offers";
-
-$csvSync = fopen("$RUN_DIR/final/woo_synced.csv","w");
-$csvDrop = fopen("$RUN_DIR/final/price_dropped.csv","w");
-$csvKeep = fopen("$RUN_DIR/final/unchanged.csv","w");
-$csvErr  = fopen("$RUN_DIR/final/errors.csv","w");
-fputcsv($csvSync,["sku","before","target","action"], ',', '"', '\\');
-fputcsv($csvDrop,["sku","from","to"], ',', '"', '\\');
-fputcsv($csvKeep,["sku","price"], ',', '"', '\\');
-fputcsv($csvErr,["sku","reason"], ',', '"', '\\');
-
-$ok=0;$drop=0;$keep=0;$err=0;
-
-$offers = $wpdb->get_results("SELECT supplier_sku, cost_usd, exchange_rate, stock_total FROM {$table}", ARRAY_A);
-foreach ($offers as $offer) {
-  $sku = $offer['supplier_sku'] ?? null;
-  if (!$sku) { continue; }
-
-  $pid = wc_get_product_id_by_sku($sku);
-  if (!$pid) { fputcsv($csvErr,[$sku,'product_not_found']); $err++; continue; }
-  $product = wc_get_product($pid);
-  if (!$product) { fputcsv($csvErr,[$sku,'wc_get_product_failed']); $err++; continue; }
-
-  $costUsd = (float) ($offer['cost_usd'] ?? 0);
-  $fx      = (float) ($offer['exchange_rate'] ?? 0);
-  $stock   = (int)   ($offer['stock_total'] ?? 0);
-  if ($costUsd <= 0 || $fx <= 0) { $fx = max($fx, 1.0); }
-
-  $baseMxn = $costUsd * $fx;
-  $margin  = 0.15; // TODO: enlazar con tabla de márgenes
-  $target  = stage09_round_margin($baseMxn * (1+$margin) * (1 + $IVA/100));
-
-  $before = stage09_current_price($product);
-  $didUpdate = false;
-  if ($before <= 0 || $target < $before) {
-    $product->set_regular_price($target);
-    $sale = $product->get_sale_price();
-    if (!$sale || floatval($sale) >= $target) {
-      $product->set_sale_price('');
+if (!function_exists('SLOG09')) {
+  function SLOG09(string $message): void {
+    global $COMP_STAGE09_LOG_HANDLE, $COMP_STAGE09_DEBUG;
+    $line = '[' . date('Y-m-d H:i:s') . "] {$message}\n";
+    if (is_resource($COMP_STAGE09_LOG_HANDLE)) {
+      fwrite($COMP_STAGE09_LOG_HANDLE, $line);
     }
-    $didUpdate = true;
-  }
-
-  $product->set_manage_stock(true);
-  $product->set_stock_quantity(max(0,$stock));
-  $product->set_stock_status($stock>0 ? 'instock' : 'outofstock');
-
-  $product->save();
-
-  if ($didUpdate) {
-    fputcsv($csvSync,[$sku,$before,$target,'lower_or_set'], ',', '"', '\\');
-    if ($before>0 && $target<$before) { fputcsv($csvDrop,[$sku,$before,$target], ',', '"', '\\'); $drop++; }
-    $ok++;
-  } else {
-    fputcsv($csvKeep,[$sku,$before], ',', '"', '\\');
-    $keep++;
+    if (!empty($COMP_STAGE09_DEBUG)) {
+      echo $line;
+    }
   }
 }
 
-SLOG09("Pricing: ok=$ok drop=$drop keep=$keep err=$err");
-
-function stage09_current_price($product){
-  $regular = (float) $product->get_regular_price();
-  $sale    = $product->get_sale_price();
-  if ($sale !== '') {
-    $saleVal = (float)$sale;
-    if ($saleVal > 0 && $saleVal < $regular) { return $saleVal; }
+if (!function_exists('compu_stage09_current_price')) {
+  /** @param WC_Product $product */
+  function compu_stage09_current_price($product): float {
+    $regular = (float) $product->get_regular_price();
+    $sale    = $product->get_sale_price();
+    if ($sale !== '') {
+      $saleVal = (float) $sale;
+      if ($saleVal > 0 && $saleVal < $regular) {
+        return $saleVal;
+      }
+    }
+    return $regular;
   }
-  return $regular;
 }
 
-function stage09_round_margin($price){
-  $p = floor($price);
-  $last = $p % 10;
-  if ($last >= 9) { $p -= $last - 9; }
-  elseif ($last >= 5) { $p -= $last - 5; }
-  else { $p -= $last; }
-  return max($p, 0);
+if (!function_exists('compu_stage09_round_margin')) {
+  function compu_stage09_round_margin(float $price): float {
+    $p = (int) floor($price);
+    $last = $p % 10;
+    if ($last >= 9) {
+      $p -= $last - 9;
+    } elseif ($last >= 5) {
+      $p -= $last - 5;
+    } else {
+      $p -= $last;
+    }
+    return (float) max($p, 0);
+  }
+}
+
+if (!function_exists('compu_stage09_normalize_bool')) {
+  /** @param mixed $value */
+  function compu_stage09_normalize_bool($value): ?bool {
+    if (is_bool($value)) {
+      return $value;
+    }
+    if (is_int($value)) {
+      return $value !== 0;
+    }
+    if (is_string($value)) {
+      $normalized = strtolower(trim($value));
+      if ($normalized === '') {
+        return null;
+      }
+      if (in_array($normalized, ['1', 'true', 'yes', 'y', 'on'], true)) {
+        return true;
+      }
+      if (in_array($normalized, ['0', 'false', 'no', 'n', 'off'], true)) {
+        return false;
+      }
+    }
+    return null;
+  }
+}
+
+if (!function_exists('compu_stage09_run')) {
+  /**
+   * Ejecuta Stage 09 (Pricing Woo).
+   *
+   * @param array{
+   *   run_dir?:string,
+   *   runDir?:string,
+   *   dir?:string,
+   *   path?:string,
+   *   iva?:float|int|string,
+   *   dry_run?:bool|int|string,
+   *   debug?:bool|int|string
+   * } $opts
+   *
+   * @return array{
+   *   status:string,
+   *   ok:bool,
+   *   run_dir:string,
+   *   dry_run:bool,
+   *   iva:float,
+   *   stats:array{
+   *     synced:int,
+   *     price_drops:int,
+   *     unchanged:int,
+   *     errored:int
+   *   },
+   *   errors:array<int,string>
+   * }
+   */
+  function compu_stage09_run(array $opts = []): array {
+    global $wpdb, $COMP_STAGE09_LOG_HANDLE, $COMP_STAGE09_DEBUG;
+
+    $result = [
+      'status' => 'error',
+      'ok' => false,
+      'run_dir' => '',
+      'dry_run' => false,
+      'iva' => 16.0,
+      'stats' => [
+        'synced' => 0,
+        'price_drops' => 0,
+        'unchanged' => 0,
+        'errored' => 0,
+      ],
+      'errors' => [],
+    ];
+
+    $debugRaw = $opts['debug'] ?? getenv('DEBUG');
+    $COMP_STAGE09_DEBUG = compu_stage09_normalize_bool($debugRaw) ?? ((int) $debugRaw !== 0);
+    $COMP_STAGE09_LOG_HANDLE = null;
+
+    $runDir = compu_import_resolve_run_dir($opts);
+    $result['run_dir'] = $runDir;
+    if ($runDir === '') {
+      $result['errors'][] = 'run_dir_missing: No se pudo determinar RUN_DIR.';
+      return $result;
+    }
+    if (!is_dir($runDir)) {
+      $result['errors'][] = 'run_dir_not_found: Directorio inexistente (' . $runDir . ').';
+      return $result;
+    }
+
+    $logDir = $runDir . '/logs';
+    $finalDir = $runDir . '/final';
+    if (!is_dir($logDir)) { @mkdir($logDir, 0775, true); }
+    if (!is_dir($finalDir)) { @mkdir($finalDir, 0775, true); }
+
+    $logHandle = @fopen($logDir . '/stage09.log', 'a');
+    if (is_resource($logHandle)) {
+      $COMP_STAGE09_LOG_HANDLE = $logHandle;
+    }
+
+    $csvHandles = [];
+    $closeResources = function () use (&$csvHandles, &$COMP_STAGE09_LOG_HANDLE, &$COMP_STAGE09_DEBUG, $logHandle): void {
+      foreach ($csvHandles as $handle) {
+        if (is_resource($handle)) {
+          fclose($handle);
+        }
+      }
+      $csvHandles = [];
+      if (is_resource($COMP_STAGE09_LOG_HANDLE ?? null)) {
+        fclose($COMP_STAGE09_LOG_HANDLE);
+      } elseif (is_resource($logHandle)) {
+        fclose($logHandle);
+      }
+      $COMP_STAGE09_LOG_HANDLE = null;
+      $COMP_STAGE09_DEBUG = 0;
+    };
+
+    try {
+      if (!isset($wpdb) || !is_object($wpdb)) {
+        $result['errors'][] = 'wpdb_unavailable: Objeto $wpdb no disponible.';
+        SLOG09('Abortando: $wpdb no disponible.');
+        return $result;
+      }
+
+      if (!function_exists('wc_get_product_id_by_sku') || !function_exists('wc_get_product')) {
+        $result['errors'][] = 'woocommerce_missing: WooCommerce no está cargado.';
+        SLOG09('WooCommerce no cargado; abortando stage 09.');
+        return $result;
+      }
+
+      $iva = null;
+      if (array_key_exists('iva', $opts) && $opts['iva'] !== '' && $opts['iva'] !== null) {
+        $iva = (float) $opts['iva'];
+      } else {
+        $ivaEnv = getenv('IVA');
+        if ($ivaEnv === false || $ivaEnv === '') {
+          $ivaEnv = getenv('IVA_DEFAULT');
+        }
+        if ($ivaEnv !== false && $ivaEnv !== '') {
+          $iva = (float) $ivaEnv;
+        }
+      }
+      if ($iva === null || !is_finite($iva)) {
+        $iva = 16.0;
+      }
+      $result['iva'] = $iva;
+
+      $dryRun = null;
+      if (array_key_exists('dry_run', $opts)) {
+        $dryRun = compu_stage09_normalize_bool($opts['dry_run']);
+      }
+      if ($dryRun === null) {
+        $dryEnv = getenv('DRY_RUN');
+        if ($dryEnv !== false && $dryEnv !== '') {
+          $dryRun = compu_stage09_normalize_bool($dryEnv);
+          if ($dryRun === null) {
+            $dryRun = ((int) $dryEnv) !== 0;
+          }
+        }
+      }
+      if ($dryRun === null) {
+        $dryRun = false;
+      }
+      $dryRun = (bool) $dryRun;
+      $result['dry_run'] = $dryRun;
+
+      $table = $wpdb->prefix . 'compu_offers';
+      try {
+        $offers = $wpdb->get_results(
+          "SELECT supplier_sku, cost_usd, exchange_rate, stock_total FROM {$table}",
+          ARRAY_A
+        );
+      } catch (Throwable $th) {
+        $result['errors'][] = 'offers_query_failed: ' . $th->getMessage();
+        SLOG09('Error consultando compu_offers: ' . $th->getMessage());
+        return $result;
+      }
+
+      if (empty($offers)) {
+        $result['errors'][] = 'offers_empty: compu_offers sin registros.';
+        SLOG09('No hay registros en compu_offers.');
+        return $result;
+      }
+
+      $csvPaths = [
+        'sync' => $finalDir . '/woo_synced.csv',
+        'drop' => $finalDir . '/price_dropped.csv',
+        'keep' => $finalDir . '/unchanged.csv',
+        'err'  => $finalDir . '/errors.csv',
+      ];
+      foreach ($csvPaths as $key => $path) {
+        $handle = @fopen($path, 'w');
+        if (!is_resource($handle)) {
+          $result['errors'][] = 'file_open_failed: ' . basename($path);
+          SLOG09('No se pudo abrir archivo: ' . $path);
+          return $result;
+        }
+        $csvHandles[$key] = $handle;
+      }
+
+      fputcsv($csvHandles['sync'], ['sku', 'before', 'target', 'action'], ',', '"', '\\');
+      fputcsv($csvHandles['drop'], ['sku', 'from', 'to'], ',', '"', '\\');
+      fputcsv($csvHandles['keep'], ['sku', 'price'], ',', '"', '\\');
+      fputcsv($csvHandles['err'],  ['sku', 'reason'], ',', '"', '\\');
+
+      foreach ($offers as $offer) {
+        $sku = $offer['supplier_sku'] ?? null;
+        if (!$sku) {
+          $result['stats']['errored']++;
+          fputcsv($csvHandles['err'], ['', 'missing_sku'], ',', '"', '\\');
+          continue;
+        }
+
+        $productId = wc_get_product_id_by_sku($sku);
+        if (!$productId) {
+          $result['stats']['errored']++;
+          fputcsv($csvHandles['err'], [$sku, 'product_not_found'], ',', '"', '\\');
+          continue;
+        }
+
+        $product = wc_get_product($productId);
+        if (!$product) {
+          $result['stats']['errored']++;
+          fputcsv($csvHandles['err'], [$sku, 'wc_get_product_failed'], ',', '"', '\\');
+          continue;
+        }
+
+        $costUsd = (float) ($offer['cost_usd'] ?? 0);
+        $fx      = (float) ($offer['exchange_rate'] ?? 0);
+        $stock   = (int)   ($offer['stock_total'] ?? 0);
+        if ($costUsd <= 0 || $fx <= 0) {
+          $fx = max($fx, 1.0);
+        }
+
+        $baseMxn = $costUsd * ($fx > 0 ? $fx : 1.0);
+        $margin  = 0.15; // TODO: enlazar con tabla de márgenes
+        $target  = compu_stage09_round_margin($baseMxn * (1 + $margin) * (1 + ($iva / 100)));
+
+        $before = compu_stage09_current_price($product);
+        $shouldUpdate = ($before <= 0 || $target < $before);
+        $priceDropped = ($before > 0 && $target < $before);
+
+        if (!$dryRun) {
+          if ($shouldUpdate) {
+            $product->set_regular_price($target);
+            $sale = $product->get_sale_price();
+            if ($sale === '' || !is_numeric($sale) || floatval($sale) >= $target) {
+              $product->set_sale_price('');
+            }
+          }
+
+          $product->set_manage_stock(true);
+          $product->set_stock_quantity(max(0, $stock));
+          $product->set_stock_status($stock > 0 ? 'instock' : 'outofstock');
+
+          $product->save();
+        }
+
+        if ($shouldUpdate) {
+          $result['stats']['synced']++;
+          $action = $dryRun ? 'dry_run' : 'lower_or_set';
+          fputcsv($csvHandles['sync'], [$sku, $before, $target, $action], ',', '"', '\\');
+          if ($priceDropped) {
+            $result['stats']['price_drops']++;
+            fputcsv($csvHandles['drop'], [$sku, $before, $target], ',', '"', '\\');
+          }
+        } else {
+          $result['stats']['unchanged']++;
+          fputcsv($csvHandles['keep'], [$sku, $before], ',', '"', '\\');
+        }
+      }
+
+      $result['status'] = 'ok';
+      $result['ok'] = true;
+      SLOG09(
+        sprintf(
+          'Pricing: synced=%d drops=%d unchanged=%d errors=%d%s',
+          $result['stats']['synced'],
+          $result['stats']['price_drops'],
+          $result['stats']['unchanged'],
+          $result['stats']['errored'],
+          $dryRun ? ' (dry-run)' : ''
+        )
+      );
+
+      return $result;
+    } finally {
+      $closeResources();
+    }
+  }
 }


### PR DESCRIPTION
Título sugerido:
feat(cron): runner 02→06 endurecido + comandos wp compu:* + cron único + tests

Descripción (pégala tal cual):

Endurece 02→06 con defaults seguros y resolución de SOURCE_CSV/CSV_SRC.

Refactor de 08/09 para CLI (evita redeclare, acepta --run_dir/--input_jsonl).

Nuevos comandos: wp compu:offers, wp compu:pricing.

Script ci/cron-compu.sh (orquesta 02→06→08→09, logs y manejo de errores).

Test tests/cron_smoke.sh.

Docs de Cron & CLI actualizadas.
Checklist:

 wp compu:offers --help y wp compu:pricing --help muestran ayuda.

 tests/cron_smoke.sh retorna 0.

 ci/cron-compu.sh corre sin intervención.

 No hay “Cannot redeclare …”.

## Summary
- add a shared helper to resolve the run directory with option and environment fallbacks
- update stage 08 to rely on the shared helper for consistent run directory resolution
- wrap stage 09 logic inside `compu_stage09_run`, add argument/env handling for IVA and dry-run, and improve error reporting and logging safety

## Testing
- php -l server-mirror/compu-import-lego/includes/stages/09-pricing.php
- php -l server-mirror/compu-import-lego/includes/stages/08-offers.php

------
https://chatgpt.com/codex/tasks/task_b_68e1eb41e04083208713f44d072f207f