### PR TITLE
Fix Stage 01/02 normalization workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Thumbs.db
 venv/
 .env
 __pycache__/
+tests/tmp/
 
 # Dependencias innecesarias
 node_modules/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: stage01_02
+
+stage01_02:
+	bash tests/run_stage01_02.sh

--- a/README.md
+++ b/README.md
@@ -61,6 +61,27 @@ Repositorio central para el proyecto **Compustar**, integraciones y scripts rela
 - Este repo está pensado para usarse con GitHub y AICodex.
 - Recuerda mantener fuera de Git cualquier credencial sensible (`.env` ya está en .gitignore).
 
+## Stage 01–02 (repo)
+
+### Requisitos
+- PHP 8+ con extensiones estándar (json, iconv o intl).
+- Python 3.8+ y `jq` para las verificaciones.
+
+### Comandos de ejemplo
+```bash
+bash tests/run_stage01_02.sh \
+  --csv data/ProductosHora_subset_1000_5000.csv \
+  --run_dir tests/tmp/run-$$
+
+make stage01_02
+```
+
+### Checks obligatorios
+- `source.csv` se crea en el RUN_DIR, mantiene el encabezado original y tiene más de una fila.
+- `normalized.jsonl` y `normalized.csv` existen, comparten las mismas columnas normalizadas y cada objeto/registro incluye `SKU` (copiado desde `Modelo`).
+- Los nombres de columna se normalizan quitando acentos y reemplazando espacios por guiones bajos.
+- Los conteos de filas entre `source.csv`, `normalized.jsonl` y `normalized.csv` son consistentes.
+
 > Roles/RACI/DoD: ver documento “Equipo y responsabilidades” y la sección de operación del diario.
 <!-- END:CCX_REPOS_SUMMARY -->
 > Roles/RACI/DoD: ver documento “Equipo y responsabilidades” y la sección de operación del diario.

--- a/server-mirror/compu-import-lego/includes/stages/01-fetch.php
+++ b/server-mirror/compu-import-lego/includes/stages/01-fetch.php
@@ -1,2 +1,150 @@
-<?php if (!defined('ABSPATH')) { exit; }
-class Compu_Stage_Fetch { public function run($args){ $file=$args['file'] ?? COMPU_IMPORT_DEFAULT_CSV; if(!file_exists($file)){ \WP_CLI::error("No encuentro el archivo: {$file}"); } $run_id=compu_import_run_open($args['source'] ?? 'syscom',$file); $base=compu_import_get_base_dir(); $dir=trailingslashit($base).'run-'.$run_id; compu_import_mkdir($dir); $dest=trailingslashit($dir).'source.csv'; copy($file,$dest); compu_import_log($run_id,'fetch','info','Archivo copiado',['src'=>$file,'dest'=>$dest]); \WP_CLI::success("Run {$run_id} inicializado. Fuente copiada a {$dest}"); } }
+<?php
+if (!defined('ABSPATH')) {
+  exit;
+}
+
+class Compu_Stage_Fetch {
+  /**
+   * @param array<string,mixed> $args
+   */
+  public function run($args) {
+    $sourceFile = $this->resolveSourceFile($args);
+    if (!file_exists($sourceFile)) {
+      $this->cli_error("No encuentro el archivo: {$sourceFile}");
+    }
+
+    $runSetup = $this->resolveRunDirectory($args, $sourceFile);
+    $runDir   = $runSetup['dir'];
+    $runId    = $runSetup['id'];
+
+    if (!is_dir($runDir) && !mkdir($runDir, 0777, true) && !is_dir($runDir)) {
+      $this->cli_error("No se pudo crear el directorio de ejecución: {$runDir}");
+    }
+
+    $destination = rtrim($runDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'source.csv';
+
+    if (!copy($sourceFile, $destination)) {
+      $this->cli_error('No se pudo copiar el archivo fuente al directorio de ejecución.');
+    }
+
+    $this->cli_log("Fuente copiada a {$destination}");
+    if ($runId !== null) {
+      $this->compu_log($runId, 'fetch', 'info', 'Archivo copiado', [
+        'src'  => $sourceFile,
+        'dest' => $destination,
+      ]);
+      $this->cli_success("Run {$runId} inicializado. Fuente copiada a {$destination}");
+    }
+  }
+
+  /**
+   * @param array<string,mixed> $args
+   */
+  private function resolveSourceFile(array $args): string {
+    $candidates = [];
+    foreach (['file', 'csv', 'source'] as $key) {
+      if (!empty($args[$key])) {
+        $candidates[] = (string) $args[$key];
+      }
+    }
+    $envCsv = getenv('CSV');
+    if ($envCsv !== false && $envCsv !== '') {
+      $candidates[] = (string) $envCsv;
+    }
+    if (defined('COMPU_IMPORT_DEFAULT_CSV')) {
+      $candidates[] = (string) COMPU_IMPORT_DEFAULT_CSV;
+    }
+    foreach ($candidates as $candidate) {
+      $candidate = trim($candidate);
+      if ($candidate !== '') {
+        return $candidate;
+      }
+    }
+    $this->cli_error('No se indicó un archivo CSV fuente.');
+    return '';
+  }
+
+  /**
+   * @param array<string,mixed> $args
+   * @return array{id: int|null, dir: string}
+   */
+  private function resolveRunDirectory(array $args, string $sourceFile): array {
+    $runDirCandidates = [];
+    foreach (['run-dir', 'run_dir', 'runDir', 'dir', 'path'] as $key) {
+      if (!empty($args[$key])) {
+        $runDirCandidates[] = (string) $args[$key];
+      }
+    }
+    foreach (['RUN_DIR', 'RUN_PATH'] as $envKey) {
+      $envValue = getenv($envKey);
+      if ($envValue !== false && $envValue !== '') {
+        $runDirCandidates[] = (string) $envValue;
+      }
+    }
+
+    foreach ($runDirCandidates as $candidate) {
+      $candidate = rtrim(trim($candidate), DIRECTORY_SEPARATOR);
+      if ($candidate !== '') {
+        return [
+          'id'  => null,
+          'dir' => $candidate,
+        ];
+      }
+    }
+
+    if (function_exists('compu_import_run_open') &&
+        function_exists('compu_import_get_base_dir') &&
+        function_exists('compu_import_mkdir')) {
+      $runId = compu_import_run_open($args['source'] ?? 'syscom', $sourceFile);
+      $base  = compu_import_get_base_dir();
+      $dir   = rtrim($this->trailingslashit($base) . 'run-' . $runId, DIRECTORY_SEPARATOR);
+      compu_import_mkdir($dir);
+      return [
+        'id'  => (int) $runId,
+        'dir' => $dir,
+      ];
+    }
+
+    $this->cli_error('No se pudo determinar el directorio de ejecución (run dir).');
+    return ['id' => null, 'dir' => ''];
+  }
+
+  private function trailingslashit(string $path): string {
+    if (function_exists('trailingslashit')) {
+      return trailingslashit($path);
+    }
+    return rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+  }
+
+  private function cli_error(string $message): void {
+    if (class_exists('\\WP_CLI')) {
+      \WP_CLI::error($message);
+    }
+    throw new \RuntimeException($message);
+  }
+
+  private function cli_success(string $message): void {
+    if (class_exists('\\WP_CLI')) {
+      \WP_CLI::success($message);
+    }
+  }
+
+  private function cli_log(string $message): void {
+    if (class_exists('\\WP_CLI')) {
+      \WP_CLI::log($message);
+    }
+  }
+
+  /**
+   * @param int $runId
+   * @param string $stage
+   * @param string $level
+   * @param string $message
+   * @param array<string,mixed> $context
+   */
+  private function compu_log($runId, $stage, $level, $message, array $context = []): void {
+    if (function_exists('compu_import_log')) {
+      compu_import_log($runId, $stage, $level, $message, $context);
+    }
+  }
+}

--- a/tests/run_stage01_02.sh
+++ b/tests/run_stage01_02.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CSV="data/ProductosHora_subset_1000_5000.csv"
+RUN_DIR="tests/tmp/run-$(date +%s)"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --csv=*)
+      CSV="${1#*=}"
+      shift
+      ;;
+    --run_dir=*)
+      RUN_DIR="${1#*=}"
+      shift
+      ;;
+    --run-dir=*)
+      RUN_DIR="${1#*=}"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+mkdir -p "${RUN_DIR}"
+
+php tests/stage_runner.php 01-fetch --file="${CSV}" --run-dir="${RUN_DIR}" >/dev/null
+php tests/stage_runner.php 02-normalize --run-dir="${RUN_DIR}" >/dev/null
+
+SOURCE_CSV="${RUN_DIR}/source.csv"
+NORMALIZED_JSONL="${RUN_DIR}/normalized.jsonl"
+NORMALIZED_CSV="${RUN_DIR}/normalized.csv"
+
+if [[ ! -f "${SOURCE_CSV}" ]]; then
+  echo "Falta ${SOURCE_CSV}" >&2
+  exit 1
+fi
+
+if [[ $(wc -l <"${SOURCE_CSV}") -le 1 ]]; then
+  echo "source.csv no contiene datos" >&2
+  exit 1
+fi
+
+if ! diff -q <(head -n1 "${CSV}") <(head -n1 "${SOURCE_CSV}") >/dev/null; then
+  echo "El encabezado de source.csv no coincide con el CSV de entrada" >&2
+  exit 1
+fi
+
+if [[ ! -f "${NORMALIZED_JSONL}" ]]; then
+  echo "Falta ${NORMALIZED_JSONL}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${NORMALIZED_CSV}" ]]; then
+  echo "Falta ${NORMALIZED_CSV}" >&2
+  exit 1
+fi
+
+python - "$CSV" "$SOURCE_CSV" "$NORMALIZED_JSONL" "$NORMALIZED_CSV" <<'PY'
+import csv
+import json
+import sys
+import unicodedata
+from pathlib import Path
+
+csv_path = Path(sys.argv[1])
+source_path = Path(sys.argv[2])
+jsonl_path = Path(sys.argv[3])
+norm_csv_path = Path(sys.argv[4])
+
+if not jsonl_path.read_text(encoding="utf-8", errors="ignore").strip():
+    sys.stderr.write("normalized.jsonl está vacío\n")
+    sys.exit(1)
+
+def normalize_header(value: str) -> str:
+    value = value.strip()
+    value = unicodedata.normalize("NFD", value)
+    value = "".join(ch for ch in value if unicodedata.category(ch) != "Mn")
+    value = unicodedata.normalize("NFC", value)
+    value = value.replace("\xa0", " ")
+    while "  " in value:
+        value = value.replace("  ", " ")
+    value = value.replace("\t", " ")
+    value = value.replace("\n", " ")
+    import re
+    value = re.sub(r"\s+", "_", value)
+    value = re.sub(r"[^A-Za-z0-9_]", "_", value)
+    value = re.sub(r"_+", "_", value)
+    return value.strip("_")
+
+with source_path.open(newline="", encoding="utf-8", errors="ignore") as fh:
+    reader = csv.reader(fh)
+    source_header = next(reader)
+    source_rows = sum(1 for _ in reader)
+
+expected_keys = [normalize_header(col) for col in source_header]
+
+json_rows = []
+with jsonl_path.open(encoding="utf-8", errors="ignore") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        json_rows.append(json.loads(line))
+
+if not json_rows:
+    sys.stderr.write("normalized.jsonl no contiene filas\n")
+    sys.exit(1)
+
+first_keys = list(json_rows[0].keys())
+expected_set = set(expected_keys)
+for key in expected_set:
+    if key and key not in first_keys:
+        sys.stderr.write(f"La clave normalizada '{key}' no está presente en normalized.jsonl\n")
+        sys.exit(1)
+
+sku_values = [row.get("SKU", "") for row in json_rows]
+if any(value == "" for value in sku_values):
+    sys.stderr.write("Existen filas con SKU vacío\n")
+    sys.exit(1)
+
+modelo_key = "Modelo"
+if modelo_key not in first_keys:
+    sys.stderr.write("No se encontró la columna Modelo normalizada\n")
+    sys.exit(1)
+
+for row in json_rows[:10]:
+    if row.get("SKU", "") != row.get(modelo_key, ""):
+        sys.stderr.write("El SKU no coincide con Modelo en algunas filas\n")
+        sys.exit(1)
+
+with norm_csv_path.open(newline="", encoding="utf-8", errors="ignore") as fh:
+    reader = csv.reader(fh)
+    norm_header = next(reader)
+    norm_rows = list(reader)
+
+if norm_header != first_keys:
+    sys.stderr.write("normalized.csv y normalized.jsonl difieren en columnas u orden\n")
+    sys.exit(1)
+
+if len(json_rows) != len(norm_rows):
+    sys.stderr.write("normalized.jsonl y normalized.csv tienen distinto número de filas\n")
+    sys.exit(1)
+
+if len(json_rows) not in (source_rows, source_rows - 1):
+    sys.stderr.write("El conteo de filas normalizadas no coincide con source.csv\n")
+    sys.exit(1)
+
+PY
+
+echo "Stage 01 y Stage 02 completados correctamente en ${RUN_DIR}" >&2

--- a/tests/stage_runner.php
+++ b/tests/stage_runner.php
@@ -1,0 +1,66 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+$rootDir = dirname(__DIR__);
+if (!defined('ABSPATH')) {
+    define('ABSPATH', $rootDir . DIRECTORY_SEPARATOR);
+}
+
+if ($argc < 2) {
+    fwrite(STDERR, "Uso: stage_runner.php <stage> [--opciones]\n");
+    exit(1);
+}
+
+$stage = $argv[1];
+$args  = parse_args(array_slice($argv, 2));
+
+try {
+    switch ($stage) {
+        case '01-fetch':
+            require_once $rootDir . '/server-mirror/compu-import-lego/includes/stages/01-fetch.php';
+            $runner = new Compu_Stage_Fetch();
+            $runner->run($args);
+            break;
+        case '02-normalize':
+            require_once $rootDir . '/server-mirror/compu-import-lego/includes/stages/02-normalize.php';
+            $runner = new Compu_Stage_Normalize();
+            $runner->run($args);
+            break;
+        default:
+            throw new RuntimeException("Stage desconocido: {$stage}");
+    }
+} catch (Throwable $e) {
+    fwrite(STDERR, $e->getMessage() . "\n");
+    exit(1);
+}
+
+function parse_args(array $input): array
+{
+    $result = [];
+    $count  = count($input);
+    for ($i = 0; $i < $count; $i++) {
+        $token = $input[$i];
+        if (strncmp($token, '--', 2) !== 0) {
+            continue;
+        }
+        $token = substr($token, 2);
+        if ($token === '') {
+            continue;
+        }
+        $parts = explode('=', $token, 2);
+        if (count($parts) === 2) {
+            $result[$parts[0]] = $parts[1];
+            continue;
+        }
+        $key = $parts[0];
+        $nextIndex = $i + 1;
+        if ($nextIndex < $count && strncmp($input[$nextIndex], '--', 2) !== 0) {
+            $result[$key] = $input[$nextIndex];
+            $i++;
+        } else {
+            $result[$key] = true;
+        }
+    }
+    return $result;
+}


### PR DESCRIPTION
## Summary
- update Stage 01 to copy the source CSV into a provided run directory when running outside of WordPress
- rewrite Stage 02 to normalize headers, populate SKU from Modelo, and emit JSONL/CSV artifacts with UTF-8-safe data
- add standalone runner, orchestration script, Makefile target, documentation, and ignore rule for tests/tmp

## Testing
- bash tests/run_stage01_02.sh --csv data/ProductosHora_subset_1000_5000.csv --run_dir tests/tmp/run-$$

------
https://chatgpt.com/codex/tasks/task_b_68e2ca4a9c708320a494d90b2054d99b