### PR TITLE
Add stage 01 local copy provisioning

### DIFF
--- a/htdocs/compu-run-cron.php
+++ b/htdocs/compu-run-cron.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+$baseRunDir = __DIR__ . '/wp-content/uploads/compu-import';
+if (!is_dir($baseRunDir) && !@mkdir($baseRunDir, 0775, true) && !is_dir($baseRunDir)) {
+    fwrite(STDERR, "[cron] FAILED_TO_CREATE_BASE_DIR $baseRunDir\n");
+    exit(10);
+}
+
+$runId = (string) (time());
+$runDir = $baseRunDir . '/run-' . $runId;
+if (!is_dir($runDir) && !@mkdir($runDir, 0775, true) && !is_dir($runDir)) {
+    fwrite(STDERR, "[cron] FAILED_TO_CREATE_RUN_DIR $runDir\n");
+    exit(11);
+}
+
+$token = getenv('COMPU_RUN_TOKEN');
+if ($token === false || $token === '') {
+    $token = 'dev-compustar-token';
+    putenv('COMPU_RUN_TOKEN=' . $token);
+}
+
+echo "RUN_DIR=$runDir\n";
+
+$_GET = [
+    'token'   => $token,
+    'stage'   => '01',
+    'run_id'  => $runId,
+    'run_dir' => $runDir,
+];
+
+require __DIR__ . '/compu-run-normalize.php';

--- a/htdocs/compu-run-normalize.php
+++ b/htdocs/compu-run-normalize.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+// Parse CLI arguments into $_GET for convenience when executed via CLI.
+if (PHP_SAPI === 'cli' && isset($argv) && is_array($argv)) {
+    foreach (array_slice($argv, 1) as $arg) {
+        if (strpos($arg, '=') !== false) {
+            [$key, $value] = explode('=', $arg, 2);
+            $_GET[$key] = $value;
+        }
+    }
+}
+
+$expectedToken = getenv('COMPU_RUN_TOKEN');
+if ($expectedToken === false || $expectedToken === '') {
+    $expectedToken = 'dev-compustar-token';
+}
+
+$providedToken = isset($_GET['token']) ? (string) $_GET['token'] : '';
+if (!hash_equals($expectedToken, $providedToken)) {
+    echo "[auth] INVALID_TOKEN\n";
+    exit(99);
+}
+
+$runId = isset($_GET['run_id']) ? trim((string) $_GET['run_id']) : '';
+if ($runId === '') {
+    echo "[runner] MISSING_RUN_ID\n";
+    exit(98);
+}
+
+$stage = isset($_GET['stage']) ? (string) $_GET['stage'] : '';
+if ($stage === '') {
+    echo "[runner] MISSING_STAGE\n";
+    exit(97);
+}
+
+switch ($stage) {
+    case '01':
+        // === stage 01: preparar source.csv desde copia local (provisional) ===
+        if (isset($_GET['stage']) && $_GET['stage'] === '01') {
+            $runDir = isset($_GET['run_dir']) ? rtrim((string) $_GET['run_dir'], '/') : null;
+            $src    = '/home/compustar/ProductosHora.csv'; // INSUMO PROVISIONAL
+            if (!$runDir || !is_dir($runDir)) {
+                echo "[stage01] INVALID_RUN_DIR\n";
+                exit(1);
+            }
+            if (!is_readable($src)) {
+                echo "[stage01] SOURCE_MISSING $src\n";
+                exit(2);
+            }
+            $dst = $runDir . '/source.csv';
+            // Copiar (sobrescribe si ya existe para idempotencia de pruebas)
+            if (!@copy($src, $dst)) {
+                echo "[stage01] COPY_FAILED $src -> $dst\n";
+                exit(3);
+            }
+            @chmod($dst, 0664);
+            // Si el proceso no tiene permisos para chown/chgrp, ignora errores
+            @chown($dst, 'compustar'); @chgrp($dst, 'compustar');
+            echo "[stage01] SOURCE_READY $dst\n";
+            exit(0);
+        }
+        break;
+    case '02':
+        echo "[stage02] NOT_IMPLEMENTED\n";
+        exit(96);
+    case '03':
+    case '04':
+    case '05':
+    case '06':
+    case '07':
+    case '08':
+    case '09':
+    case '10':
+    case '11':
+        echo "[stage{$stage}] NOT_IMPLEMENTED\n";
+        exit(95);
+    default:
+        echo "[runner] UNKNOWN_STAGE {$stage}\n";
+        exit(94);
+}


### PR DESCRIPTION
## Summary
- add a cron helper that prepares a run directory and forwards execution to the normalize bridge
- add the normalize bridge with token/run validation and the new Stage 01 copy workflow from the provisional ProductosHora.csv

## Testing
- php /home/compustar/htdocs/compu-run-cron.php

------
https://chatgpt.com/codex/tasks/task_b_68e435bf1e2c832086146fc2b2f5bc16