### PR TITLE
Add unified CLI kernel runner for import pipeline

### DIFF
--- a/OPERATE.md
+++ b/OPERATE.md
@@ -1,0 +1,31 @@
+# Compu Import Unified Runner
+
+## CLI entrypoint
+- Script: `/home/compustar/htdocs/compu-run.php` (PHP CLI).
+- Example full run: `php /home/compustar/htdocs/compu-run.php --stages=02..06 --dry-run=0 --require-term=1`.
+- Subset example (02..06, 201 rows starting at 1000): `php /home/compustar/htdocs/compu-run.php --stages=02..06 --from=1000 --rows=201 --limit=0 --offset=0`.
+- Exit codes: `0` success/only warnings, `2` input/config errors, `3` stage failure.
+
+## Flags & environment
+- `--stages=` accepts ranges (`02..06`) or lists (`02,03,04`).
+- `--dry-run`, `--require-term`, `--sample600`, `--limit`, `--offset`, `--from`/`--rows` (subset aliases), `--csv` (source override), `--run-base`, `--run-dir`, `--run-id`, `--wp-root`, `--plugin-dir`, `--wp-cli`, `--php-bin`.
+- Environment overrides (`export VAR=...`): `WP_ROOT`, `PLUGIN_DIR`, `RUN_BASE`, `CSV_SRC`, `SOURCE_MASTER`, `DRY_RUN`, `LIMIT`, `OFFSET`, `REQUIRE_TERM`, `SAMPLE600`, `SUBSET_FROM`, `SUBSET_ROWS`.
+
+## Run directory layout
+- A new `RUN_ID` (e.g. `20251007-161639-0392a3`) is created under `RUN_BASE` (`wp-content/uploads/compu-import`).
+- Structure:
+  - `source.csv` → symlink/copy of input CSV when provided.
+  - `logs/run.log` → overall JSONL timeline.
+  - `logs/stage-XX.log` → per-stage JSONL (same schema).
+  - `final/` → stage outputs (`imported.csv`, `updated.csv`, `skipped.csv`, `summary.json`, etc.).
+  - `tmp/` → scratch area per stage.
+
+## Logging & observability
+- JSONL record shape: `{ "ts": ISO8601, "stage": "XX", "level": "INFO|WARN|ERROR|METRIC|DONE", ... }`.
+- Metrics are attached via `level="METRIC"` and include `rows_in`, `rows_out`, `skipped`, `duration_ms`, plus stage-specific counters.
+- `run.log` aggregates every stage record; per-stage files mirror only their own events.
+
+## Summary interpretation
+- `final/summary.json` consolidates each stage status (`OK|WARN|ERROR`), metrics, artifacts, and notes.
+- Treat WARN as actionable checks (e.g., missing artifacts, dry-runs, skipped rows). ERROR stops the pipeline and returns exit code `3`.
+- Artifacts list absolute paths (CSV/JSONL/logs) for regression and handoff.

--- a/docs/examples/run-log-sample.jsonl
+++ b/docs/examples/run-log-sample.jsonl
@@ -1,0 +1,15 @@
+{"ts":"2025-10-07T16:16:39+00:00","stage":"RUN","level":"INFO","msg":"Run started","run_id":"20251007-161639-0392a3","stages":["02","03","04","05","06"]}
+{"ts":"2025-10-07T16:16:39+00:00","stage":"02","level":"INFO","msg":"Starting stage","title":"Normalize source CSV"}
+{"ts":"2025-10-07T16:16:39+00:00","stage":"02","level":"WARN","msg":"Missing input artifact","artifact":"source.csv"}
+{"ts":"2025-10-07T16:16:39+00:00","stage":"02","level":"METRIC","metrics":{"dry_run":1,"duration_ms":0}}
+{"ts":"2025-10-07T16:16:39+00:00","stage":"02","level":"INFO","notes":"Dry-run: skipped stage execution"}
+{"ts":"2025-10-07T16:16:39+00:00","stage":"02","level":"WARN","msg":"Expected output artifact missing","artifact":"normalized.jsonl"}
+{"ts":"2025-10-07T16:16:39+00:00","stage":"02","level":"WARN","msg":"Expected output artifact missing","artifact":"normalized.csv"}
+{"ts":"2025-10-07T16:16:39+00:00","stage":"02","level":"DONE","status":"WARN"}
+{"ts":"2025-10-07T16:16:39+00:00","stage":"03","level":"INFO","msg":"Starting stage","title":"Validate normalized data"}
+{"ts":"2025-10-07T16:16:39+00:00","stage":"03","level":"WARN","msg":"Missing input artifact","artifact":"normalized.jsonl"}
+{"ts":"2025-10-07T16:16:39+00:00","stage":"03","level":"METRIC","metrics":{"dry_run":1,"duration_ms":0}}
+{"ts":"2025-10-07T16:16:39+00:00","stage":"03","level":"INFO","notes":"Dry-run: skipped stage execution"}
+{"ts":"2025-10-07T16:16:39+00:00","stage":"03","level":"WARN","msg":"Expected output artifact missing","artifact":"validated.jsonl"}
+{"ts":"2025-10-07T16:16:39+00:00","stage":"03","level":"DONE","status":"WARN"}
+{"ts":"2025-10-07T16:16:39+00:00","stage":"04","level":"INFO","msg":"Starting stage","title":"Resolve category mapping"}

--- a/docs/examples/summary-sample.json
+++ b/docs/examples/summary-sample.json
@@ -1,0 +1,52 @@
+{
+    "run_id": "20251007-161639-0392a3",
+    "status": "WARN",
+    "stages": {
+        "02": {
+            "status": "WARN",
+            "metrics": {
+                "dry_run": 1,
+                "duration_ms": 0
+            },
+            "artifacts": [],
+            "notes": "Dry-run: skipped stage execution"
+        },
+        "03": {
+            "status": "WARN",
+            "metrics": {
+                "dry_run": 1,
+                "duration_ms": 0
+            },
+            "artifacts": [],
+            "notes": "Dry-run: skipped stage execution"
+        },
+        "04": {
+            "status": "WARN",
+            "metrics": {
+                "dry_run": 1,
+                "duration_ms": 0
+            },
+            "artifacts": [],
+            "notes": "Dry-run: skipped stage execution"
+        },
+        "05": {
+            "status": "WARN",
+            "metrics": {
+                "dry_run": 1,
+                "duration_ms": 0
+            },
+            "artifacts": [],
+            "notes": "Dry-run: stage skipped"
+        },
+        "06": {
+            "status": "WARN",
+            "metrics": {
+                "dry_run": 1,
+                "duration_ms": 0
+            },
+            "artifacts": [],
+            "notes": "Dry-run: skipped stage execution"
+        }
+    },
+    "generated_at": "2025-10-07T16:16:39+00:00"
+}

--- a/htdocs/compu-run.php
+++ b/htdocs/compu-run.php
@@ -1,0 +1,206 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+use CompuImport\Kernel\StageKernel;
+
+function compu_run_parse_args(array $argv): array {
+    $options = [];
+    foreach (array_slice($argv, 1) as $arg) {
+        if ($arg === '--help' || $arg === '-h') {
+            $options['help'] = true;
+            continue;
+        }
+        if (substr($arg, 0, 2) !== '--') {
+            continue;
+        }
+        $arg = substr($arg, 2);
+        if (strpos($arg, '=') !== false) {
+            [$key, $value] = explode('=', $arg, 2);
+        } else {
+            $key = $arg;
+            $value = '1';
+        }
+        $options[strtolower(str_replace('-', '_', $key))] = $value;
+    }
+    return $options;
+}
+
+function compu_run_print_help(): void {
+    $help = <<<TEXT
+Compu Import unified runner
+Usage:
+  php compu-run.php --stages=02..06 [options]
+
+Options:
+  --stages=LIST          Stage list (e.g. 02..06 or 02,03,04)
+  --dry-run=0|1          Skip execution and only prepare run context
+  --require-term=0|1     Require taxonomy term mapping (propagated to stages)
+  --limit=N              Limit records processed by applicable stages
+  --offset=N             Skip first N records (stage 06)
+  --from=N               Start subset at row N (alias of --subset-from)
+  --rows=N               Number of rows for subset (alias of --subset-rows)
+  --csv=PATH             Source CSV file to link as source.csv
+  --run-base=PATH        Override RUN_BASE directory
+  --run-dir=PATH         Reuse an existing run directory
+  --run-id=VALUE         Provide a run identifier (otherwise generated)
+  --wp-root=PATH         Override WordPress root
+  --plugin-dir=PATH      Override plugin directory
+  --wp-cli=PATH          Path to wp binary (default /usr/local/bin/wp)
+  --php-bin=PATH         PHP binary for sub-process stages (default PHP_BINARY)
+  --help                 Show this message
+TEXT;
+    fwrite(STDOUT, $help . "\n");
+}
+
+function compu_run_expand_stages(string $spec): array {
+    $spec = trim($spec);
+    if ($spec === '') {
+        return [];
+    }
+
+    $parts = [];
+
+    if (strpos($spec, '..') !== false) {
+        [$start, $end] = explode('..', $spec, 2);
+        if ($start === '' || $end === '') {
+            return [];
+        }
+        $startInt = (int) $start;
+        $endInt = (int) $end;
+        if ($startInt <= 0 || $endInt <= 0 || $startInt > $endInt) {
+            return [];
+        }
+        for ($i = $startInt; $i <= $endInt; $i++) {
+            $parts[] = str_pad((string) $i, 2, '0', STR_PAD_LEFT);
+        }
+        return $parts;
+    }
+
+    foreach (explode(',', $spec) as $item) {
+        $item = trim($item);
+        if ($item === '') {
+            continue;
+        }
+        if (!preg_match('/^\d{2}$/', $item)) {
+            return [];
+        }
+        $parts[] = $item;
+    }
+
+    return array_values(array_unique($parts));
+}
+
+function compu_run_exit(int $code, string $message = ''): void {
+    if ($message !== '') {
+        if ($code === 0) {
+            fwrite(STDOUT, $message . "\n");
+        } else {
+            fwrite(STDERR, $message . "\n");
+        }
+    }
+    exit($code);
+}
+
+$argv = $_SERVER['argv'] ?? [];
+$options = compu_run_parse_args($argv);
+
+if (!empty($options['help'])) {
+    compu_run_print_help();
+    exit(0);
+}
+
+$stageSpec = $options['stages'] ?? '02..06';
+$stages = compu_run_expand_stages($stageSpec);
+if (empty($stages)) {
+    compu_run_exit(2, 'Invalid --stages specification');
+}
+
+$wpRoot = $options['wp_root'] ?? getenv('WP_ROOT') ?: __DIR__;
+$wpLoad = rtrim($wpRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'wp-load.php';
+if (!is_file($wpLoad)) {
+    compu_run_exit(2, "Cannot locate wp-load.php at {$wpLoad}");
+}
+
+require_once $wpLoad;
+
+$pluginDir = $options['plugin_dir'] ?? getenv('PLUGIN_DIR') ?: ($wpRoot . '/wp-content/plugins/compu-import-lego');
+if (!is_dir($pluginDir)) {
+    compu_run_exit(2, "Plugin directory not found: {$pluginDir}");
+}
+
+$runBase = $options['run_base'] ?? getenv('RUN_BASE') ?: ($wpRoot . '/wp-content/uploads/compu-import');
+$phpBin = $options['php_bin'] ?? PHP_BINARY;
+$wpCli = $options['wp_cli'] ?? '/usr/local/bin/wp';
+
+require_once $pluginDir . '/includes/kernel/StageInterface.php';
+require_once $pluginDir . '/includes/kernel/StageResult.php';
+require_once $pluginDir . '/includes/kernel/RunLogger.php';
+require_once $pluginDir . '/includes/kernel/stages/Stage02.php';
+require_once $pluginDir . '/includes/kernel/stages/Stage03.php';
+require_once $pluginDir . '/includes/kernel/stages/Stage04.php';
+require_once $pluginDir . '/includes/kernel/stages/Stage06.php';
+require_once $pluginDir . '/includes/kernel/StageKernel.php';
+
+$kernel = new StageKernel($wpRoot, $pluginDir, $runBase, $phpBin, $wpCli);
+
+$contextOptions = [];
+$map = [
+    'dry_run' => 'DRY_RUN',
+    'require_term' => 'REQUIRE_TERM',
+    'limit' => 'LIMIT',
+    'offset' => 'OFFSET',
+    'from' => 'SUBSET_FROM',
+    'rows' => 'SUBSET_ROWS',
+    'subset_from' => 'SUBSET_FROM',
+    'subset_rows' => 'SUBSET_ROWS',
+    'csv' => 'CSV_SRC',
+    'source' => 'CSV_SRC',
+    'source_master' => 'SOURCE_MASTER',
+    'sample600' => 'SAMPLE600',
+    'run_dir' => 'RUN_DIR',
+    'run_id' => 'RUN_ID',
+];
+
+foreach ($map as $optionKey => $contextKey) {
+    if (isset($options[$optionKey])) {
+        $value = $options[$optionKey];
+        if (in_array($contextKey, ['DRY_RUN', 'REQUIRE_TERM', 'LIMIT', 'OFFSET', 'SUBSET_FROM', 'SUBSET_ROWS', 'SAMPLE600'], true)) {
+            $value = (int) $value;
+        }
+        $contextOptions[$contextKey] = $value;
+    }
+}
+
+$contextOptions['CSV_SRC'] = $contextOptions['CSV_SRC'] ?? ($options['csv_src'] ?? null);
+if ($contextOptions['CSV_SRC'] === null) {
+    unset($contextOptions['CSV_SRC']);
+}
+
+fwrite(STDOUT, '[compu-run] stages=' . implode(',', $stages) . "\n");
+
+try {
+    $result = $kernel->run($stages, $contextOptions);
+} catch (Throwable $e) {
+    compu_run_exit(3, 'Kernel execution failed: ' . $e->getMessage());
+}
+
+$summary = $result['summary'] ?? [];
+$runId = $summary['run_id'] ?? ($result['context']['RUN_ID'] ?? 'unknown');
+$runDir = $result['context']['RUN_DIR'] ?? '';
+$summaryPath = $result['summary_path'] ?? '';
+$status = $result['status'] ?? 'ERROR';
+
+fwrite(STDOUT, '[compu-run] run_id=' . $runId . "\n");
+if ($runDir !== '') {
+    fwrite(STDOUT, '[compu-run] run_dir=' . $runDir . "\n");
+}
+if ($summaryPath !== '') {
+    fwrite(STDOUT, '[compu-run] summary=' . $summaryPath . "\n");
+}
+
+if ($status === 'ERROR') {
+    compu_run_exit(3, 'One or more stages failed');
+}
+
+compu_run_exit(0, 'Run completed with status ' . $status);

--- a/htdocs/wp-load.php
+++ b/htdocs/wp-load.php
@@ -1,0 +1,78 @@
+<?php
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+if (!function_exists('trailingslashit')) {
+    function trailingslashit(string $value): string {
+        return rtrim($value, "\\/") . '/';
+    }
+}
+
+if (!function_exists('remove_accents')) {
+    function remove_accents(string $value): string {
+        return $value;
+    }
+}
+
+if (!function_exists('wp_upload_dir')) {
+    function wp_upload_dir(): array {
+        $base = getenv('WP_UPLOAD_BASE');
+        if (!$base) {
+            $base = ABSPATH . 'wp-content/uploads';
+        }
+        if (!is_dir($base)) {
+            @mkdir($base, 0775, true);
+        }
+        return [
+            'basedir' => rtrim($base, '/'),
+            'baseurl' => 'http://example.com/uploads',
+        ];
+    }
+}
+
+if (!class_exists('wpdb')) {
+    class wpdb
+    {
+        public $prefix = 'wp_';
+
+        public function get_var($query)
+        {
+            return 0;
+        }
+
+        public function get_col($query)
+        {
+            return [];
+        }
+
+        public function insert($table, $data)
+        {
+        }
+
+        public function update($table, $data, $where)
+        {
+        }
+
+        public function query($sql)
+        {
+        }
+
+        public function prepare($query, ...$args)
+        {
+            return $query;
+        }
+    }
+}
+
+global $wpdb;
+if (!isset($wpdb) || !($wpdb instanceof wpdb)) {
+    $wpdb = new wpdb();
+}
+
+if (!function_exists('compu_import_now')) {
+    function compu_import_now(): string
+    {
+        return gmdate('Y-m-d H:i:s');
+    }
+}

--- a/server-mirror/compu-import-lego/includes/kernel/RunLogger.php
+++ b/server-mirror/compu-import-lego/includes/kernel/RunLogger.php
@@ -1,0 +1,99 @@
+<?php
+namespace CompuImport\Kernel;
+
+class RunLogger
+{
+    /** @var string */
+    private $runLog;
+
+    /** @var string */
+    private $stageLogDir;
+
+    /**
+     * @var resource[]
+     */
+    private $handles = [];
+
+    public function __construct(string $runLog, string $stageLogDir)
+    {
+        $this->runLog = $runLog;
+        $this->stageLogDir = rtrim($stageLogDir, DIRECTORY_SEPARATOR);
+        if (!is_dir($this->stageLogDir)) {
+            mkdir($this->stageLogDir, 0775, true);
+        }
+    }
+
+    public function logRun(string $level, array $payload): void
+    {
+        $this->writeLine('RUN', $level, $payload, $this->runLog);
+    }
+
+    public function logStage(string $stageId, string $level, array $payload = []): void
+    {
+        $stageFile = $this->stageLogPath($stageId);
+        $this->writeLine($stageId, $level, $payload, $stageFile);
+        $this->writeLine($stageId, $level, $payload, $this->runLog);
+    }
+
+    public function close(): void
+    {
+        foreach ($this->handles as $handle) {
+            fclose($handle);
+        }
+        $this->handles = [];
+    }
+
+    private function stageLogPath(string $stageId): string
+    {
+        $safe = preg_replace('/[^0-9A-Za-z_-]/', '-', $stageId);
+        return $this->stageLogDir . DIRECTORY_SEPARATOR . 'stage-' . $safe . '.log';
+    }
+
+    private function writeLine(string $stage, string $level, array $payload, string $file): void
+    {
+        $record = array_merge([
+            'ts' => gmdate('c'),
+            'stage' => $stage,
+            'level' => strtoupper($level),
+        ], $payload);
+
+        $json = json_encode($record, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($json === false) {
+            $json = json_encode([
+                'ts' => gmdate('c'),
+                'stage' => $stage,
+                'level' => 'ERROR',
+                'msg' => 'Failed to encode log payload',
+            ]);
+        }
+
+        $handle = $this->handleFor($file);
+        if ($handle) {
+            fwrite($handle, $json . "\n");
+            fflush($handle);
+        }
+    }
+
+    /**
+     * @param string $file
+     * @return resource|null
+     */
+    private function handleFor(string $file)
+    {
+        if (isset($this->handles[$file])) {
+            return $this->handles[$file];
+        }
+
+        $dir = dirname($file);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+
+        $handle = fopen($file, 'a');
+        if ($handle === false) {
+            return null;
+        }
+        $this->handles[$file] = $handle;
+        return $handle;
+    }
+}

--- a/server-mirror/compu-import-lego/includes/kernel/StageInterface.php
+++ b/server-mirror/compu-import-lego/includes/kernel/StageInterface.php
@@ -1,0 +1,36 @@
+<?php
+namespace CompuImport\Kernel;
+
+interface StageInterface
+{
+    /**
+     * Returns the numeric identifier of the stage (e.g. "02").
+     */
+    public function id(): string;
+
+    /**
+     * Human readable title for logging.
+     */
+    public function title(): string;
+
+    /**
+     * Declares expected input artifact names.
+     *
+     * @return string[]
+     */
+    public function inputs(): array;
+
+    /**
+     * Declares output artifact names produced by the stage.
+     *
+     * @return string[]
+     */
+    public function outputs(): array;
+
+    /**
+     * Executes the stage and returns a result payload.
+     *
+     * @param array<string,mixed> $context
+     */
+    public function run(array $context): StageResult;
+}

--- a/server-mirror/compu-import-lego/includes/kernel/StageKernel.php
+++ b/server-mirror/compu-import-lego/includes/kernel/StageKernel.php
@@ -1,0 +1,454 @@
+<?php
+namespace CompuImport\Kernel;
+
+use CompuImport\Kernel\Stages\Stage02;
+use CompuImport\Kernel\Stages\Stage03;
+use CompuImport\Kernel\Stages\Stage04;
+use CompuImport\Kernel\Stages\Stage06;
+
+class StageKernel
+{
+    /** @var string */
+    private $wpRoot;
+
+    /** @var string */
+    private $pluginDir;
+
+    /** @var string */
+    private $runBase;
+
+    /** @var string */
+    private $phpBinary;
+
+    /** @var string */
+    private $wpCliBinary;
+
+    /** @var array<string,array<string,mixed>> */
+    private $stageDefinitions = [];
+
+    public function __construct(string $wpRoot, string $pluginDir, string $runBase, string $phpBinary = 'php', string $wpCliBinary = 'wp')
+    {
+        $this->wpRoot = rtrim($wpRoot, DIRECTORY_SEPARATOR);
+        $this->pluginDir = rtrim($pluginDir, DIRECTORY_SEPARATOR);
+        $this->runBase = rtrim($runBase, DIRECTORY_SEPARATOR);
+        $this->phpBinary = $phpBinary;
+        $this->wpCliBinary = $wpCliBinary;
+        $this->buildStageDefinitions();
+    }
+
+    /**
+     * @param array<int,string> $stageIds
+     * @param array<string,mixed> $options
+     * @return array<string,mixed>
+     */
+    public function run(array $stageIds, array $options = []): array
+    {
+        [$context, $logger] = $this->initializeRun($options);
+        $results = [];
+        $overallStatus = StageResult::STATUS_OK;
+
+        $logger->logRun('INFO', [
+            'msg' => 'Run started',
+            'run_id' => $context['RUN_ID'],
+            'stages' => $stageIds,
+        ]);
+
+        foreach ($stageIds as $stageId) {
+            if (!isset($this->stageDefinitions[$stageId])) {
+                $logger->logRun('ERROR', ['msg' => "Stage {$stageId} not defined"]);
+                $overallStatus = StageResult::STATUS_ERROR;
+                break;
+            }
+
+            $definition = $this->stageDefinitions[$stageId];
+            $title = $definition['title'];
+            $logger->logStage($stageId, 'INFO', [
+                'msg' => 'Starting stage',
+                'title' => $title,
+            ]);
+
+            $this->assertInputs($stageId, $definition, $context, $logger);
+
+            $startTime = microtime(true);
+            $result = $this->executeStage($stageId, $definition, $context, $logger);
+            $durationMs = (int) round((microtime(true) - $startTime) * 1000);
+            if (!isset($result->metrics['duration_ms'])) {
+                $result->metrics['duration_ms'] = $durationMs;
+            }
+
+            $logger->logStage($stageId, 'METRIC', [
+                'metrics' => $result->metrics,
+            ]);
+
+            if ($result->notes) {
+                $logger->logStage($stageId, 'INFO', ['notes' => $result->notes]);
+            }
+
+            $this->assertOutputs($stageId, $definition, $context, $logger);
+
+            $logger->logStage($stageId, 'DONE', [
+                'status' => $result->status,
+            ]);
+
+            $results[$stageId] = [
+                'status' => $result->status,
+                'metrics' => $result->metrics,
+                'artifacts' => array_filter($result->artifacts, function ($value) {
+                    return is_string($value) && $value !== '';
+                }),
+                'notes' => $result->notes,
+            ];
+
+            if ($result->status === StageResult::STATUS_ERROR) {
+                $overallStatus = StageResult::STATUS_ERROR;
+                break;
+            }
+
+            if ($result->status === StageResult::STATUS_WARN && $overallStatus === StageResult::STATUS_OK) {
+                $overallStatus = StageResult::STATUS_WARN;
+            }
+        }
+
+        $summary = [
+            'run_id' => $context['RUN_ID'],
+            'status' => $overallStatus,
+            'stages' => $results,
+            'generated_at' => gmdate('c'),
+        ];
+
+        $summaryPath = $context['RUN_DIR'] . DIRECTORY_SEPARATOR . 'final' . DIRECTORY_SEPARATOR . 'summary.json';
+        file_put_contents($summaryPath, json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        $logger->logRun('INFO', [
+            'msg' => 'Run finished',
+            'status' => $overallStatus,
+            'summary' => $summaryPath,
+        ]);
+        $logger->close();
+
+        return [
+            'status' => $overallStatus,
+            'summary' => $summary,
+            'summary_path' => $summaryPath,
+            'context' => $context,
+        ];
+    }
+
+    /**
+     * @return array{0:array<string,mixed>,1:RunLogger}
+     */
+    private function initializeRun(array $options): array
+    {
+        $defaults = [
+            'CSV_SRC' => getenv('CSV_SRC') ?: ($options['CSV_SRC'] ?? ''),
+            'SOURCE_MASTER' => getenv('SOURCE_MASTER') ?: ($options['SOURCE_MASTER'] ?? ''),
+            'DRY_RUN' => (int) ($options['DRY_RUN'] ?? getenv('DRY_RUN') ?: 0),
+            'LIMIT' => (int) ($options['LIMIT'] ?? getenv('LIMIT') ?: 0),
+            'OFFSET' => (int) ($options['OFFSET'] ?? getenv('OFFSET') ?: 0),
+            'REQUIRE_TERM' => (int) ($options['REQUIRE_TERM'] ?? getenv('REQUIRE_TERM') ?: 0),
+            'SAMPLE600' => (int) ($options['SAMPLE600'] ?? getenv('SAMPLE600') ?: 0),
+            'SUBSET_FROM' => (int) ($options['SUBSET_FROM'] ?? getenv('SUBSET_FROM') ?: 0),
+            'SUBSET_ROWS' => (int) ($options['SUBSET_ROWS'] ?? getenv('SUBSET_ROWS') ?: 0),
+        ];
+
+        $runId = $options['RUN_ID'] ?? $this->generateRunId();
+        $runDir = $options['RUN_DIR'] ?? ($this->runBase . DIRECTORY_SEPARATOR . 'run-' . $runId);
+
+        $this->ensureDirectory($runDir);
+        $this->ensureDirectory($runDir . DIRECTORY_SEPARATOR . 'logs');
+        $this->ensureDirectory($runDir . DIRECTORY_SEPARATOR . 'final');
+        $this->ensureDirectory($runDir . DIRECTORY_SEPARATOR . 'tmp');
+
+        if ($defaults['CSV_SRC'] === '' && defined('COMPU_IMPORT_DEFAULT_CSV')) {
+            $defaults['CSV_SRC'] = COMPU_IMPORT_DEFAULT_CSV;
+        }
+
+        if ($defaults['SOURCE_MASTER'] === '' && defined('COMPU_IMPORT_DEFAULT_CSV')) {
+            $defaults['SOURCE_MASTER'] = COMPU_IMPORT_DEFAULT_CSV;
+        }
+
+        $context = array_merge($defaults, [
+            'RUN_ID' => $runId,
+            'RUN_DIR' => $runDir,
+            'RUN_PATH' => $runDir,
+            'RUN_BASE' => $this->runBase,
+        ]);
+
+        $this->exportContextEnv($context);
+        $this->prepareSourceCsv($context);
+
+        $runLog = $runDir . DIRECTORY_SEPARATOR . 'logs' . DIRECTORY_SEPARATOR . 'run.log';
+        $stageLogDir = $runDir . DIRECTORY_SEPARATOR . 'logs';
+        $logger = new RunLogger($runLog, $stageLogDir);
+
+        return [$context, $logger];
+    }
+
+    /**
+     * @param array<string,mixed> $definition
+     * @param array<string,mixed> $context
+     */
+    private function executeStage(string $stageId, array $definition, array $context, RunLogger $logger): StageResult
+    {
+        $this->ensureWpCliStub();
+
+        if ($definition['type'] === 'php') {
+            /** @var StageInterface $handler */
+            $handler = $definition['handler'];
+            return $handler->run($context);
+        }
+
+        if ($definition['type'] === 'wp-cli') {
+            if (!empty($context['DRY_RUN'])) {
+                return new StageResult(
+                    StageResult::STATUS_WARN,
+                    ['dry_run' => 1],
+                    [],
+                    'Dry-run: stage skipped'
+                );
+            }
+            $command = $this->buildWpCliCommand($definition['eval']);
+            $env = $this->collectEnvForStage($context, $stageId);
+            $descriptorSpec = [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ];
+            $process = proc_open($command, $descriptorSpec, $pipes, $this->wpRoot, $env);
+            $stdout = '';
+            $stderr = '';
+            $exitCode = 1;
+
+            if (is_resource($process)) {
+                fclose($pipes[0]);
+                $stdout = stream_get_contents($pipes[1]);
+                fclose($pipes[1]);
+                $stderr = stream_get_contents($pipes[2]);
+                fclose($pipes[2]);
+                $exitCode = proc_close($process);
+            }
+
+            $metrics = ['rows_in' => 0, 'rows_out' => 0, 'skipped' => 0];
+            $parsedMetrics = $this->parseJsonMetrics($stdout);
+            if ($parsedMetrics) {
+                $metrics = array_merge($metrics, $parsedMetrics);
+            }
+
+            $logger->logStage($stageId, 'INFO', [
+                'stdout' => trim($stdout),
+                'stderr' => trim($stderr),
+            ]);
+
+            return new StageResult(
+                $exitCode === 0 ? StageResult::STATUS_OK : StageResult::STATUS_ERROR,
+                $metrics,
+                [
+                    'stdout' => $this->writeStageOutput($context, $stageId, 'stdout.log', $stdout),
+                    'stderr' => $this->writeStageOutput($context, $stageId, 'stderr.log', $stderr),
+                ],
+                $exitCode === 0 ? null : 'Stage exited with code ' . $exitCode
+            );
+        }
+
+        return new StageResult(StageResult::STATUS_ERROR, [], [], 'Unknown stage type');
+    }
+
+    private function buildStageDefinitions(): void
+    {
+        $this->stageDefinitions = [];
+        $stage02 = new Stage02();
+        $stage03 = new Stage03();
+        $stage04 = new Stage04();
+        $stage06 = new Stage06($this->phpBinary, $this->pluginDir . '/includes/stages/06-products.php');
+
+        foreach ([$stage02, $stage03, $stage04, $stage06] as $handler) {
+            $this->stageDefinitions[$handler->id()] = [
+                'type' => 'php',
+                'title' => $handler->title(),
+                'handler' => $handler,
+                'inputs' => $handler->inputs(),
+                'outputs' => $handler->outputs(),
+            ];
+        }
+
+        $this->stageDefinitions['05'] = [
+            'type' => 'wp-cli',
+            'title' => 'Term resolver',
+            'eval' => 'define("COMP_RUN_STAGE", true); include_once "' . addslashes($this->pluginDir . '/includes/stages/05-terms.php') . '";',
+            'inputs' => ['resolved.jsonl', 'validated.jsonl'],
+            'outputs' => ['terms_resolved.jsonl'],
+        ];
+
+        $wpStages = [
+            '07' => ['file' => '/includes/stages/07-media.php', 'title' => 'Media sync'],
+            '08' => ['file' => '/includes/stages/08-offers.php', 'title' => 'Offers sync'],
+            '09' => ['file' => '/includes/stages/09-pricing.php', 'title' => 'Pricing adjustments'],
+            '10' => ['file' => '/includes/stages/10-publish.php', 'title' => 'Publish products'],
+            '11' => ['file' => '/includes/stages/11-report.php', 'title' => 'Generate report'],
+        ];
+
+        foreach ($wpStages as $id => $stage) {
+            $this->stageDefinitions[$id] = [
+                'type' => 'wp-cli',
+                'title' => $stage['title'],
+                'eval' => 'define("COMP_RUN_STAGE", true); include_once "' . addslashes($this->pluginDir . $stage['file']) . '";',
+                'inputs' => [],
+                'outputs' => [],
+            ];
+        }
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function collectEnvForStage(array $context, string $stageId): array
+    {
+        $env = $_ENV;
+        $keys = ['RUN_ID', 'RUN_DIR', 'RUN_PATH', 'RUN_BASE', 'CSV_SRC', 'SOURCE_MASTER', 'DRY_RUN', 'LIMIT', 'OFFSET', 'REQUIRE_TERM', 'SAMPLE600', 'SUBSET_FROM', 'SUBSET_ROWS'];
+        foreach ($keys as $key) {
+            if (isset($context[$key])) {
+                $env[$key] = (string) $context[$key];
+            }
+        }
+        $env['COMP_RUN_STAGE_ID'] = $stageId;
+        return $env;
+    }
+
+    private function ensureDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            mkdir($dir, 02775, true);
+        }
+        @chmod($dir, 02775);
+        @chown($dir, 'compustar');
+        @chgrp($dir, 'compustar');
+    }
+
+    private function generateRunId(): string
+    {
+        try {
+            $random = substr(bin2hex(random_bytes(3)), 0, 6);
+        } catch (\Throwable $e) {
+            $random = (string) mt_rand(100000, 999999);
+        }
+        return date('Ymd-His') . '-' . $random;
+    }
+
+    private function prepareSourceCsv(array $context): void
+    {
+        $csvSrc = (string) ($context['CSV_SRC'] ?? '');
+        if ($csvSrc === '' || !is_file($csvSrc)) {
+            return;
+        }
+        $destination = $context['RUN_DIR'] . DIRECTORY_SEPARATOR . 'source.csv';
+        if (file_exists($destination)) {
+            return;
+        }
+        if (!@symlink($csvSrc, $destination)) {
+            @copy($csvSrc, $destination);
+        }
+        @chmod($destination, 0664);
+        @chown($destination, 'compustar');
+        @chgrp($destination, 'compustar');
+    }
+
+    private function exportContextEnv(array $context): void
+    {
+        foreach ($context as $key => $value) {
+            if (is_scalar($value) || $value === null) {
+                $stringValue = $value === null ? '' : (string) $value;
+                putenv($key . '=' . $stringValue);
+                $_ENV[$key] = $stringValue;
+            }
+        }
+    }
+
+    private function ensureWpCliStub(): void
+    {
+        if (!class_exists('\\WP_CLI')) {
+            class_alias(StubWpCli::class, '\\WP_CLI');
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $definition
+     * @param array<string,mixed> $context
+     */
+    private function assertInputs(string $stageId, array $definition, array $context, RunLogger $logger): void
+    {
+        $inputs = $definition['inputs'] ?? [];
+        foreach ($inputs as $input) {
+            $path = $context['RUN_DIR'] . DIRECTORY_SEPARATOR . $input;
+            if (!file_exists($path)) {
+                $logger->logStage($stageId, 'WARN', ['msg' => 'Missing input artifact', 'artifact' => $input]);
+            }
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $definition
+     * @param array<string,mixed> $context
+     */
+    private function assertOutputs(string $stageId, array $definition, array $context, RunLogger $logger): void
+    {
+        $outputs = $definition['outputs'] ?? [];
+        foreach ($outputs as $output) {
+            $path = $context['RUN_DIR'] . DIRECTORY_SEPARATOR . $output;
+            if (!file_exists($path)) {
+                $logger->logStage($stageId, 'WARN', ['msg' => 'Expected output artifact missing', 'artifact' => $output]);
+            }
+        }
+    }
+
+    private function parseJsonMetrics(string $stdout): array
+    {
+        $lines = preg_split('/\r?\n/', trim($stdout));
+        $lines = $lines ?: [];
+        foreach ($lines as $line) {
+            $decoded = json_decode(trim($line), true);
+            if (is_array($decoded) && isset($decoded['stage'])) {
+                $metrics = $decoded;
+                unset($metrics['stage']);
+                return $metrics;
+            }
+        }
+        return [];
+    }
+
+    private function writeStageOutput(array $context, string $stageId, string $fileName, string $contents): string
+    {
+        if (trim($contents) === '') {
+            return '';
+        }
+        $logsDir = $context['RUN_DIR'] . DIRECTORY_SEPARATOR . 'logs';
+        $path = $logsDir . DIRECTORY_SEPARATOR . 'stage-' . $stageId . '-' . $fileName;
+        file_put_contents($path, $contents);
+        return $path;
+    }
+
+    private function buildWpCliCommand(string $evalCode): string
+    {
+        $cmd = escapeshellcmd($this->wpCliBinary);
+        $cmd .= ' --path=' . escapeshellarg($this->wpRoot);
+        $cmd .= ' eval ' . escapeshellarg($evalCode);
+        return $cmd;
+    }
+}
+
+class StubWpCli
+{
+    public static function log($message): void
+    {
+        fwrite(STDOUT, '[WP_CLI] ' . $message . "\n");
+    }
+
+    public static function error($message): void
+    {
+        throw new \RuntimeException(is_string($message) ? $message : json_encode($message));
+    }
+
+    public static function success($message): void
+    {
+        self::log($message);
+    }
+}

--- a/server-mirror/compu-import-lego/includes/kernel/StageResult.php
+++ b/server-mirror/compu-import-lego/includes/kernel/StageResult.php
@@ -1,0 +1,41 @@
+<?php
+namespace CompuImport\Kernel;
+
+class StageResult
+{
+    public const STATUS_OK = 'OK';
+    public const STATUS_WARN = 'WARN';
+    public const STATUS_ERROR = 'ERROR';
+
+    /**
+     * @var string
+     */
+    public $status;
+
+    /**
+     * @var array<string,mixed>
+     */
+    public $metrics;
+
+    /**
+     * @var array<string,string>
+     */
+    public $artifacts;
+
+    /**
+     * @var string|null
+     */
+    public $notes;
+
+    /**
+     * @param array<string,mixed> $metrics
+     * @param array<string,string> $artifacts
+     */
+    public function __construct(string $status, array $metrics = [], array $artifacts = [], ?string $notes = null)
+    {
+        $this->status = $status;
+        $this->metrics = $metrics;
+        $this->artifacts = $artifacts;
+        $this->notes = $notes;
+    }
+}

--- a/server-mirror/compu-import-lego/includes/kernel/stages/Stage02.php
+++ b/server-mirror/compu-import-lego/includes/kernel/stages/Stage02.php
@@ -1,0 +1,139 @@
+<?php
+namespace CompuImport\Kernel\Stages;
+
+use CompuImport\Kernel\StageInterface;
+use CompuImport\Kernel\StageResult;
+
+class Stage02 implements StageInterface
+{
+    /** @var \Compu_Stage_Normalize|null */
+    private $stage;
+
+    public function __construct()
+    {
+        if (class_exists('\\Compu_Stage_Normalize')) {
+            $this->stage = new \Compu_Stage_Normalize();
+        }
+    }
+
+    public function id(): string
+    {
+        return '02';
+    }
+
+    public function title(): string
+    {
+        return 'Normalize source CSV';
+    }
+
+    public function inputs(): array
+    {
+        return ['source.csv'];
+    }
+
+    public function outputs(): array
+    {
+        return ['normalized.jsonl', 'normalized.csv'];
+    }
+
+    public function run(array $context): StageResult
+    {
+        $runDir = rtrim((string)($context['RUN_DIR'] ?? ''), DIRECTORY_SEPARATOR);
+        if ($runDir === '') {
+            return new StageResult(StageResult::STATUS_ERROR, [], [], 'Missing RUN_DIR for stage 02');
+        }
+
+        if (!empty($context['DRY_RUN'])) {
+            return new StageResult(StageResult::STATUS_WARN, ['dry_run' => 1], [], 'Dry-run: skipped stage execution');
+        }
+
+        if ($this->stage === null) {
+            return new StageResult(StageResult::STATUS_ERROR, [], [], 'Stage 02 class Compu_Stage_Normalize not found');
+        }
+
+        $args = ['run-dir' => $runDir];
+        $started = microtime(true);
+        try {
+            $this->stage->run($args);
+        } catch (\Throwable $e) {
+            return new StageResult(
+                StageResult::STATUS_ERROR,
+                ['exception' => get_class($e)],
+                [],
+                $e->getMessage()
+            );
+        }
+
+        $duration = (int) round((microtime(true) - $started) * 1000);
+        $normalizedCsv = $runDir . DIRECTORY_SEPARATOR . 'normalized.csv';
+        $sourceCsv = $runDir . DIRECTORY_SEPARATOR . 'source.csv';
+        $normalizedJson = $runDir . DIRECTORY_SEPARATOR . 'normalized.jsonl';
+
+        $rowsIn = $this->countCsvRows($sourceCsv, true);
+        $rowsOut = $this->countCsvRows($normalizedCsv, true);
+        $missingSku = 0;
+        $missingLvl1 = 0;
+        $missingLvl2 = 0;
+
+        if (is_file($normalizedJson)) {
+            $handle = fopen($normalizedJson, 'r');
+            if ($handle) {
+                while (($line = fgets($handle)) !== false) {
+                    $row = json_decode($line, true);
+                    if (!is_array($row)) {
+                        continue;
+                    }
+                    if (empty($row['sku'])) {
+                        $missingSku++;
+                    }
+                    if (empty($row['lvl1_id'])) {
+                        $missingLvl1++;
+                    }
+                    if (empty($row['lvl2_id'])) {
+                        $missingLvl2++;
+                    }
+                }
+                fclose($handle);
+            }
+        }
+
+        $metrics = [
+            'duration_ms' => $duration,
+            'rows_in' => $rowsIn,
+            'rows_out' => $rowsOut,
+            'skipped' => max(0, $rowsIn - $rowsOut),
+            'missing_sku' => $missingSku,
+            'missing_lvl1_id' => $missingLvl1,
+            'missing_lvl2_id' => $missingLvl2,
+        ];
+
+        return new StageResult(
+            ($missingSku === 0 && $missingLvl1 === 0 && $missingLvl2 === 0) ? StageResult::STATUS_OK : StageResult::STATUS_WARN,
+            $metrics,
+            [
+                'normalized_jsonl' => $normalizedJson,
+                'normalized_csv' => $normalizedCsv,
+            ],
+            null
+        );
+    }
+
+    private function countCsvRows(string $file, bool $hasHeader): int
+    {
+        if (!is_file($file) || !is_readable($file)) {
+            return 0;
+        }
+        $count = 0;
+        if (($handle = fopen($file, 'r')) === false) {
+            return 0;
+        }
+        while (($row = fgetcsv($handle)) !== false) {
+            $count++;
+        }
+        fclose($handle);
+        if ($hasHeader && $count > 0) {
+            $count--;
+        }
+        return $count;
+    }
+}

--- a/server-mirror/compu-import-lego/includes/kernel/stages/Stage03.php
+++ b/server-mirror/compu-import-lego/includes/kernel/stages/Stage03.php
@@ -1,0 +1,143 @@
+<?php
+namespace CompuImport\Kernel\Stages;
+
+use CompuImport\Kernel\StageInterface;
+use CompuImport\Kernel\StageResult;
+
+class Stage03 implements StageInterface
+{
+    /** @var \Compu_Stage_Validate|null */
+    private $stage;
+
+    public function __construct()
+    {
+        if (class_exists('\\Compu_Stage_Validate')) {
+            $this->stage = new \Compu_Stage_Validate();
+        }
+    }
+
+    public function id(): string
+    {
+        return '03';
+    }
+
+    public function title(): string
+    {
+        return 'Validate normalized data';
+    }
+
+    public function inputs(): array
+    {
+        return ['normalized.jsonl'];
+    }
+
+    public function outputs(): array
+    {
+        return ['validated.jsonl'];
+    }
+
+    public function run(array $context): StageResult
+    {
+        $runDir = rtrim((string)($context['RUN_DIR'] ?? ''), DIRECTORY_SEPARATOR);
+        if ($runDir === '') {
+            return new StageResult(StageResult::STATUS_ERROR, [], [], 'Missing RUN_DIR for stage 03');
+        }
+
+        if (!empty($context['DRY_RUN'])) {
+            return new StageResult(StageResult::STATUS_WARN, ['dry_run' => 1], [], 'Dry-run: skipped stage execution');
+        }
+
+        if ($this->stage === null) {
+            return new StageResult(StageResult::STATUS_ERROR, [], [], 'Stage 03 class Compu_Stage_Validate not found');
+        }
+
+        $args = [
+            'run-id' => $context['RUN_DB_ID'] ?? $context['RUN_ID'] ?? null,
+        ];
+
+        $started = microtime(true);
+        try {
+            $this->stage->run($args);
+        } catch (\Throwable $e) {
+            return new StageResult(
+                StageResult::STATUS_ERROR,
+                ['exception' => get_class($e)],
+                [],
+                $e->getMessage()
+            );
+        }
+
+        $duration = (int) round((microtime(true) - $started) * 1000);
+        $normalized = $runDir . DIRECTORY_SEPARATOR . 'normalized.jsonl';
+        $validated = $runDir . DIRECTORY_SEPARATOR . 'validated.jsonl';
+
+        $rowsIn = $this->countJsonlRows($normalized);
+        $rowsOut = $this->countJsonlRows($validated);
+        $skipped = max(0, $rowsIn - $rowsOut);
+
+        $missingSku = 0;
+        $missingLvl1 = 0;
+        $missingLvl2 = 0;
+        if (is_file($validated)) {
+            $fh = fopen($validated, 'r');
+            if ($fh) {
+                while (($line = fgets($fh)) !== false) {
+                    $row = json_decode($line, true);
+                    if (!is_array($row)) {
+                        continue;
+                    }
+                    if (empty($row['sku'])) {
+                        $missingSku++;
+                    }
+                    if (empty($row['lvl1_id'])) {
+                        $missingLvl1++;
+                    }
+                    if (empty($row['lvl2_id'])) {
+                        $missingLvl2++;
+                    }
+                }
+                fclose($fh);
+            }
+        }
+
+        $metrics = [
+            'duration_ms' => $duration,
+            'rows_in' => $rowsIn,
+            'rows_out' => $rowsOut,
+            'skipped' => $skipped,
+            'missing_sku' => $missingSku,
+            'missing_lvl1_id' => $missingLvl1,
+            'missing_lvl2_id' => $missingLvl2,
+        ];
+
+        $status = ($missingSku === 0 && $missingLvl1 === 0 && $missingLvl2 === 0)
+            ? StageResult::STATUS_OK
+            : StageResult::STATUS_WARN;
+
+        return new StageResult(
+            $status,
+            $metrics,
+            ['validated_jsonl' => $validated],
+            null
+        );
+    }
+
+    private function countJsonlRows(string $file): int
+    {
+        if (!is_file($file) || !is_readable($file)) {
+            return 0;
+        }
+        $count = 0;
+        $fh = fopen($file, 'r');
+        if (!$fh) {
+            return 0;
+        }
+        while (($line = fgets($fh)) !== false) {
+            if (trim($line) !== '') {
+                $count++;
+            }
+        }
+        fclose($fh);
+        return $count;
+    }
+}

--- a/server-mirror/compu-import-lego/includes/kernel/stages/Stage04.php
+++ b/server-mirror/compu-import-lego/includes/kernel/stages/Stage04.php
@@ -1,0 +1,140 @@
+<?php
+namespace CompuImport\Kernel\Stages;
+
+use CompuImport\Kernel\StageInterface;
+use CompuImport\Kernel\StageResult;
+
+class Stage04 implements StageInterface
+{
+    /** @var \Compu_Stage_Resolve_Map|null */
+    private $stage;
+
+    public function __construct()
+    {
+        if (class_exists('\\Compu_Stage_Resolve_Map')) {
+            $this->stage = new \Compu_Stage_Resolve_Map();
+        }
+    }
+
+    public function id(): string
+    {
+        return '04';
+    }
+
+    public function title(): string
+    {
+        return 'Resolve category mapping';
+    }
+
+    public function inputs(): array
+    {
+        return ['validated.jsonl'];
+    }
+
+    public function outputs(): array
+    {
+        return ['resolved.jsonl', 'unmapped.csv'];
+    }
+
+    public function run(array $context): StageResult
+    {
+        $runDir = rtrim((string)($context['RUN_DIR'] ?? ''), DIRECTORY_SEPARATOR);
+        if ($runDir === '') {
+            return new StageResult(StageResult::STATUS_ERROR, [], [], 'Missing RUN_DIR for stage 04');
+        }
+
+        if (!empty($context['DRY_RUN'])) {
+            return new StageResult(StageResult::STATUS_WARN, ['dry_run' => 1], [], 'Dry-run: skipped stage execution');
+        }
+
+        if ($this->stage === null) {
+            return new StageResult(StageResult::STATUS_ERROR, [], [], 'Stage 04 class Compu_Stage_Resolve_Map not found');
+        }
+
+        $args = [
+            'run-id' => $context['RUN_DB_ID'] ?? $context['RUN_ID'] ?? null,
+        ];
+
+        $started = microtime(true);
+        try {
+            $this->stage->run($args);
+        } catch (\Throwable $e) {
+            return new StageResult(
+                StageResult::STATUS_ERROR,
+                ['exception' => get_class($e)],
+                [],
+                $e->getMessage()
+            );
+        }
+
+        $duration = (int) round((microtime(true) - $started) * 1000);
+        $validated = $runDir . DIRECTORY_SEPARATOR . 'validated.jsonl';
+        $resolved = $runDir . DIRECTORY_SEPARATOR . 'resolved.jsonl';
+        $unmapped = $runDir . DIRECTORY_SEPARATOR . 'unmapped.csv';
+
+        $rowsIn = $this->countJsonlRows($validated);
+        $rowsOut = $this->countJsonlRows($resolved);
+        $skipped = max(0, $rowsIn - $rowsOut);
+
+        $unmappedRows = $this->countCsvRows($unmapped, true);
+
+        $metrics = [
+            'duration_ms' => $duration,
+            'rows_in' => $rowsIn,
+            'rows_out' => $rowsOut,
+            'skipped' => $skipped,
+            'unmapped' => $unmappedRows,
+        ];
+
+        $status = $unmappedRows > 0 ? StageResult::STATUS_WARN : StageResult::STATUS_OK;
+
+        return new StageResult(
+            $status,
+            $metrics,
+            [
+                'resolved_jsonl' => $resolved,
+                'unmapped_csv' => $unmapped,
+            ],
+            null
+        );
+    }
+
+    private function countJsonlRows(string $file): int
+    {
+        if (!is_file($file) || !is_readable($file)) {
+            return 0;
+        }
+        $count = 0;
+        $fh = fopen($file, 'r');
+        if (!$fh) {
+            return 0;
+        }
+        while (($line = fgets($fh)) !== false) {
+            if (trim($line) !== '') {
+                $count++;
+            }
+        }
+        fclose($fh);
+        return $count;
+    }
+
+    private function countCsvRows(string $file, bool $hasHeader): int
+    {
+        if (!is_file($file) || !is_readable($file)) {
+            return 0;
+        }
+        $fh = fopen($file, 'r');
+        if (!$fh) {
+            return 0;
+        }
+        $count = 0;
+        while (($row = fgetcsv($fh)) !== false) {
+            $count++;
+        }
+        fclose($fh);
+        if ($hasHeader && $count > 0) {
+            $count--;
+        }
+        return $count;
+    }
+}

--- a/server-mirror/compu-import-lego/includes/kernel/stages/Stage06.php
+++ b/server-mirror/compu-import-lego/includes/kernel/stages/Stage06.php
@@ -1,0 +1,169 @@
+<?php
+namespace CompuImport\Kernel\Stages;
+
+use CompuImport\Kernel\StageInterface;
+use CompuImport\Kernel\StageResult;
+
+class Stage06 implements StageInterface
+{
+    /** @var string */
+    private $phpBinary;
+
+    /** @var string */
+    private $stagePath;
+
+    public function __construct(string $phpBinary, string $stagePath)
+    {
+        $this->phpBinary = $phpBinary;
+        $this->stagePath = $stagePath;
+    }
+
+    public function id(): string
+    {
+        return '06';
+    }
+
+    public function title(): string
+    {
+        return 'Products simulation writer';
+    }
+
+    public function inputs(): array
+    {
+        return ['resolved.jsonl', 'validated.jsonl'];
+    }
+
+    public function outputs(): array
+    {
+        return ['final/imported.csv', 'final/updated.csv', 'final/skipped.csv'];
+    }
+
+    public function run(array $context): StageResult
+    {
+        $runDir = rtrim((string)($context['RUN_DIR'] ?? ''), DIRECTORY_SEPARATOR);
+        if ($runDir === '') {
+            return new StageResult(StageResult::STATUS_ERROR, [], [], 'Missing RUN_DIR for stage 06');
+        }
+
+        if (!empty($context['DRY_RUN'])) {
+            return new StageResult(StageResult::STATUS_WARN, ['dry_run' => 1], [], 'Dry-run: skipped stage execution');
+        }
+
+        if (!is_file($this->stagePath)) {
+            return new StageResult(StageResult::STATUS_ERROR, [], [], 'Stage 06 script not found');
+        }
+
+        $descriptorSpec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $env = array_merge($_ENV, [
+            'RUN_ID' => (string)($context['RUN_ID'] ?? ''),
+            'RUN_DIR' => $runDir,
+            'LIMIT' => (string)($context['LIMIT'] ?? ''),
+            'OFFSET' => (string)($context['OFFSET'] ?? ''),
+            'DRY_RUN' => (string)($context['DRY_RUN'] ?? ''),
+        ]);
+
+        $command = escapeshellcmd($this->phpBinary) . ' ' . escapeshellarg($this->stagePath);
+        $process = proc_open($command, $descriptorSpec, $pipes, $runDir, $env);
+        $stdout = '';
+        $stderr = '';
+        $exitCode = 1;
+
+        if (is_resource($process)) {
+            fclose($pipes[0]);
+            $stdout = stream_get_contents($pipes[1]);
+            fclose($pipes[1]);
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[2]);
+            $exitCode = proc_close($process);
+        }
+
+        $metrics = [
+            'rows_in' => $this->countInputRows($runDir),
+            'rows_out' => $this->countCsvRows($runDir . '/final/imported.csv', true)
+                + $this->countCsvRows($runDir . '/final/updated.csv', true),
+            'skipped' => $this->countCsvRows($runDir . '/final/skipped.csv', true),
+        ];
+
+        $status = $exitCode === 0 ? StageResult::STATUS_OK : StageResult::STATUS_ERROR;
+        $notes = trim($stderr) !== '' ? trim($stderr) : null;
+
+        return new StageResult(
+            $status,
+            $metrics,
+            [
+                'imported_csv' => $runDir . '/final/imported.csv',
+                'updated_csv' => $runDir . '/final/updated.csv',
+                'skipped_csv' => $runDir . '/final/skipped.csv',
+                'stdout' => $stdout !== '' ? $this->writeArtifact($runDir, 'stage06.stdout.log', $stdout) : '',
+                'stderr' => $stderr !== '' ? $this->writeArtifact($runDir, 'stage06.stderr.log', $stderr) : '',
+            ],
+            $notes
+        );
+    }
+
+    private function countInputRows(string $runDir): int
+    {
+        $resolved = $runDir . '/resolved.jsonl';
+        $validated = $runDir . '/validated.jsonl';
+        $rowsResolved = $this->countJsonlRows($resolved);
+        if ($rowsResolved > 0) {
+            return $rowsResolved;
+        }
+        return $this->countJsonlRows($validated);
+    }
+
+    private function countJsonlRows(string $file): int
+    {
+        if (!is_file($file) || !is_readable($file)) {
+            return 0;
+        }
+        $count = 0;
+        $fh = fopen($file, 'r');
+        if (!$fh) {
+            return 0;
+        }
+        while (($line = fgets($fh)) !== false) {
+            if (trim($line) !== '') {
+                $count++;
+            }
+        }
+        fclose($fh);
+        return $count;
+    }
+
+    private function countCsvRows(string $file, bool $hasHeader): int
+    {
+        if (!is_file($file) || !is_readable($file)) {
+            return 0;
+        }
+        $fh = fopen($file, 'r');
+        if (!$fh) {
+            return 0;
+        }
+        $count = 0;
+        while (($row = fgetcsv($fh)) !== false) {
+            $count++;
+        }
+        fclose($fh);
+        if ($hasHeader && $count > 0) {
+            $count--;
+        }
+        return $count;
+    }
+
+    private function writeArtifact(string $runDir, string $fileName, string $contents): string
+    {
+        $logsDir = $runDir . '/logs';
+        if (!is_dir($logsDir)) {
+            mkdir($logsDir, 0775, true);
+        }
+        $path = $logsDir . '/' . $fileName;
+        file_put_contents($path, $contents);
+        return $path;
+    }
+}


### PR DESCRIPTION
## Summary
- add kernel orchestration layer with shared StageInterface/StageResult, logging, and IO assertions
- create PHP wrappers for stages 02-04/06 plus stub wp-load and CLI entrypoint with standardized flags
- document operations and capture sample run log/summary for regression references

## Testing
- php htdocs/compu-run.php --stages=02..06 --dry-run=1 --wp-root=$(pwd)/htdocs --plugin-dir=$(pwd)/server-mirror/compu-import-lego --run-base=$(pwd)/data/runs
- php -l htdocs/compu-run.php
- php -l server-mirror/compu-import-lego/includes/kernel/StageKernel.php

------
https://chatgpt.com/codex/tasks/task_b_68e53a24e1488320894081248d2bfe74