### PR TITLE
Refactor CLI import runner and add smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ vendor/
 *.sql.zip
 *.bak
 data/ProductosHora.csv
+htdocs/wp-content/uploads/

--- a/data/cli-smoke-products.csv
+++ b/data/cli-smoke-products.csv
@@ -1,0 +1,6 @@
+sku,supplier_sku,price_usd,fx,stock,lvl1_id,lvl2_id,lvl3_id,brand,title,image_url,description
+SKU001,SUP001,10.50,18.40,25,101,201,301,BrandOne,"Starter kit A","http://example.com/a.jpg","Sample description A"
+SKU002,SUP002,15.75,18.40,40,101,202,302,BrandTwo,"Starter kit B","http://example.com/b.jpg","Sample description B"
+SKU003,SUP003,8.25,18.40,10,102,203,303,BrandThree,"Starter kit C","http://example.com/c.jpg","Sample description C"
+SKU004,SUP004,12.00,18.40,5,102,204,304,BrandOne,"Starter kit D","http://example.com/d.jpg","Sample description D"
+SKU005,SUP005,20.00,18.40,60,103,205,305,BrandFour,"Starter kit E","http://example.com/e.jpg","Sample description E"

--- a/htdocs/compu-run-cli.php
+++ b/htdocs/compu-run-cli.php
@@ -1,0 +1,54 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+if (!function_exists('compu_run_exit')) {
+    function compu_run_exit(int $code, string $message = ''): void
+    {
+        if ($message !== '') {
+            $stream = $code === 0 ? STDOUT : STDERR;
+            fwrite($stream, $message . "\n");
+        }
+        fflush(STDOUT);
+        fflush(STDERR);
+        exit($code);
+    }
+}
+
+if (PHP_SAPI !== 'cli') {
+    compu_run_exit(2, 'compu-run-cli.php must be executed from CLI');
+}
+
+$_SERVER['REQUEST_METHOD'] = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$_SERVER['REMOTE_ADDR'] = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+$_SERVER['SERVER_ADDR'] = $_SERVER['SERVER_ADDR'] ?? '127.0.0.1';
+$_SERVER['HTTP_HOST'] = $_SERVER['HTTP_HOST'] ?? 'localhost';
+$_SERVER['SERVER_NAME'] = $_SERVER['SERVER_NAME'] ?? 'localhost';
+$_SERVER['REQUEST_URI'] = $_SERVER['REQUEST_URI'] ?? '/compu-run-cli';
+$_SERVER['SERVER_PROTOCOL'] = $_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.1';
+$_SERVER['HTTP_USER_AGENT'] = $_SERVER['HTTP_USER_AGENT'] ?? 'compu-run-cli/1.0';
+
+if (!defined('DOING_CRON')) {
+    define('DOING_CRON', true);
+}
+if (!defined('WP_ADMIN')) {
+    define('WP_ADMIN', true);
+}
+if (!defined('WP_CLI')) {
+    define('WP_CLI', true);
+}
+if (!defined('WP_USE_THEMES')) {
+    define('WP_USE_THEMES', false);
+}
+
+if (!defined('WOODMART_THEME_DIR')) {
+    define('WOODMART_THEME_DIR', __DIR__ . '/wp-content/themes/woodmart');
+}
+if (!defined('WOODMART_THEME_SLUG')) {
+    define('WOODMART_THEME_SLUG', 'woodmart');
+}
+if (!defined('WOODMART_THEME_NAME')) {
+    define('WOODMART_THEME_NAME', 'Woodmart');
+}
+
+require __DIR__ . '/compu-run.php';

--- a/htdocs/compu-run.php
+++ b/htdocs/compu-run.php
@@ -4,7 +4,50 @@ declare(strict_types=1);
 
 use CompuImport\Kernel\StageKernel;
 
-function compu_run_parse_args(array $argv): array {
+const COMPU_RUN_ALLOWED_STAGES = ['02', '03', '04', '06'];
+
+if (!function_exists('compu_run_exit')) {
+    function compu_run_exit(int $code, string $message = ''): void
+    {
+        if ($message !== '') {
+            $stream = $code === 0 ? STDOUT : STDERR;
+            fwrite($stream, $message . "\n");
+        }
+        fflush(STDOUT);
+        fflush(STDERR);
+        exit($code);
+    }
+}
+
+function compu_run_help_text(): string
+{
+    return <<<TEXT
+Compu Import unified runner
+Usage:
+  php compu-run.php --stages=02..06 [options]
+
+Options:
+  --stages=LIST          Stage list (e.g. 02..06 or 02,03,04,06)
+  --dry-run=0|1          Skip execution and only prepare run context
+  --require-term=0|1     Require taxonomy term mapping (propagated to stages)
+  --limit=N              Limit records processed by applicable stages
+  --offset=N             Skip first N records (stage 06)
+  --from=N               Start subset at row N (alias of --subset-from)
+  --rows=N               Number of rows for subset (alias of --subset-rows)
+  --csv=PATH             Source CSV file to link as source.csv
+  --run-base=PATH        Override RUN_BASE directory
+  --run-dir=PATH         Reuse an existing run directory
+  --run-id=VALUE         Provide a numeric run identifier (otherwise generated)
+  --wp-root=PATH         Override WordPress root
+  --plugin-dir=PATH      Override plugin directory
+  --wp-cli=PATH          Path to wp binary (default /usr/local/bin/wp)
+  --php-bin=PATH         PHP binary for sub-process stages (default PHP_BINARY)
+  --help                 Show this message
+TEXT;
+}
+
+function compu_run_parse_args(array $argv): array
+{
     $options = [];
     foreach (array_slice($argv, 1) as $arg) {
         if ($arg === '--help' || $arg === '-h') {
@@ -26,57 +69,31 @@ function compu_run_parse_args(array $argv): array {
     return $options;
 }
 
-function compu_run_print_help(): void {
-    $help = <<<TEXT
-Compu Import unified runner
-Usage:
-  php compu-run.php --stages=02..06 [options]
-
-Options:
-  --stages=LIST          Stage list (e.g. 02..06 or 02,03,04)
-  --dry-run=0|1          Skip execution and only prepare run context
-  --require-term=0|1     Require taxonomy term mapping (propagated to stages)
-  --limit=N              Limit records processed by applicable stages
-  --offset=N             Skip first N records (stage 06)
-  --from=N               Start subset at row N (alias of --subset-from)
-  --rows=N               Number of rows for subset (alias of --subset-rows)
-  --csv=PATH             Source CSV file to link as source.csv
-  --run-base=PATH        Override RUN_BASE directory
-  --run-dir=PATH         Reuse an existing run directory
-  --run-id=VALUE         Provide a run identifier (otherwise generated)
-  --wp-root=PATH         Override WordPress root
-  --plugin-dir=PATH      Override plugin directory
-  --wp-cli=PATH          Path to wp binary (default /usr/local/bin/wp)
-  --php-bin=PATH         PHP binary for sub-process stages (default PHP_BINARY)
-  --help                 Show this message
-TEXT;
-    fwrite(STDOUT, $help . "\n");
-}
-
-function compu_run_expand_stages(string $spec): array {
+function compu_run_expand_stages(string $spec): array
+{
     $spec = trim($spec);
     if ($spec === '') {
         return [];
     }
 
-    $parts = [];
-
-    if (strpos($spec, '..') !== false) {
+    if (preg_match('/^\d{2}\.\.\d{2}$/', $spec)) {
         [$start, $end] = explode('..', $spec, 2);
-        if ($start === '' || $end === '') {
-            return [];
-        }
         $startInt = (int) $start;
         $endInt = (int) $end;
         if ($startInt <= 0 || $endInt <= 0 || $startInt > $endInt) {
             return [];
         }
-        for ($i = $startInt; $i <= $endInt; $i++) {
-            $parts[] = str_pad((string) $i, 2, '0', STR_PAD_LEFT);
+        $result = [];
+        foreach (COMPU_RUN_ALLOWED_STAGES as $stage) {
+            $value = (int) $stage;
+            if ($value >= $startInt && $value <= $endInt) {
+                $result[] = $stage;
+            }
         }
-        return $parts;
+        return $result;
     }
 
+    $result = [];
     foreach (explode(',', $spec) as $item) {
         $item = trim($item);
         if ($item === '') {
@@ -85,122 +102,284 @@ function compu_run_expand_stages(string $spec): array {
         if (!preg_match('/^\d{2}$/', $item)) {
             return [];
         }
-        $parts[] = $item;
-    }
-
-    return array_values(array_unique($parts));
-}
-
-function compu_run_exit(int $code, string $message = ''): void {
-    if ($message !== '') {
-        if ($code === 0) {
-            fwrite(STDOUT, $message . "\n");
-        } else {
-            fwrite(STDERR, $message . "\n");
+        if (!in_array($item, COMPU_RUN_ALLOWED_STAGES, true)) {
+            return [];
+        }
+        if (!in_array($item, $result, true)) {
+            $result[] = $item;
         }
     }
-    exit($code);
+
+    return $result;
 }
 
-$argv = $_SERVER['argv'] ?? [];
-$options = compu_run_parse_args($argv);
-
-if (!empty($options['help'])) {
-    compu_run_print_help();
-    exit(0);
+function compu_run_info(string $message): void
+{
+    fwrite(STDOUT, '[compu-run] ' . $message . "\n");
+    fflush(STDOUT);
 }
 
-$stageSpec = $options['stages'] ?? '02..06';
-$stages = compu_run_expand_stages($stageSpec);
-if (empty($stages)) {
-    compu_run_exit(2, 'Invalid --stages specification');
+function compu_run_generate_run_id(): string
+{
+    $timestamp = gmdate('YmdHis');
+    try {
+        $random = random_int(0, 999);
+    } catch (Throwable $e) {
+        $random = mt_rand(0, 999);
+    }
+    return $timestamp . str_pad((string) $random, 3, '0', STR_PAD_LEFT);
 }
 
-$wpRoot = $options['wp_root'] ?? getenv('WP_ROOT') ?: __DIR__;
-$wpLoad = rtrim($wpRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'wp-load.php';
-if (!is_file($wpLoad)) {
-    compu_run_exit(2, "Cannot locate wp-load.php at {$wpLoad}");
+function compu_run_normalize_run_id(?string $value): string
+{
+    if ($value === null || $value === '') {
+        return compu_run_generate_run_id();
+    }
+    $digits = preg_replace('/\D+/', '', (string) $value);
+    if ($digits === '') {
+        compu_run_exit(2, 'Provided --run-id must contain at least one digit.');
+    }
+    return $digits;
 }
 
-require_once $wpLoad;
-
-$pluginDir = $options['plugin_dir'] ?? getenv('PLUGIN_DIR') ?: ($wpRoot . '/wp-content/plugins/compu-import-lego');
-if (!is_dir($pluginDir)) {
-    compu_run_exit(2, "Plugin directory not found: {$pluginDir}");
+function compu_run_resolve_plugin_dir(string $dir): string
+{
+    $dir = rtrim($dir, DIRECTORY_SEPARATOR);
+    if ($dir !== '' && is_dir($dir)) {
+        return $dir;
+    }
+    $fallback = realpath(__DIR__ . '/../server-mirror/compu-import-lego');
+    if ($fallback && is_dir($fallback)) {
+        return rtrim($fallback, DIRECTORY_SEPARATOR);
+    }
+    return $dir;
 }
 
-$runBase = $options['run_base'] ?? getenv('RUN_BASE') ?: ($wpRoot . '/wp-content/uploads/compu-import');
-$phpBin = $options['php_bin'] ?? PHP_BINARY;
-$wpCli = $options['wp_cli'] ?? '/usr/local/bin/wp';
+function compu_run_require_file(string $path, string $description): void
+{
+    if (!is_file($path)) {
+        compu_run_exit(2, "Missing required {$description}: {$path}");
+    }
+    require_once $path;
+}
 
-require_once $pluginDir . '/includes/kernel/StageInterface.php';
-require_once $pluginDir . '/includes/kernel/StageResult.php';
-require_once $pluginDir . '/includes/kernel/RunLogger.php';
-require_once $pluginDir . '/includes/kernel/stages/Stage02.php';
-require_once $pluginDir . '/includes/kernel/stages/Stage03.php';
-require_once $pluginDir . '/includes/kernel/stages/Stage04.php';
-require_once $pluginDir . '/includes/kernel/stages/Stage06.php';
-require_once $pluginDir . '/includes/kernel/StageKernel.php';
+function compu_run_require_plugin_bootstrap(string $pluginDir): void
+{
+    $helperFiles = [
+        '/includes/helpers/helpers-common.php',
+        '/includes/helpers/helpers-db.php',
+        '/includes/compu-guards.php',
+    ];
+    foreach ($helperFiles as $helper) {
+        compu_run_require_file($pluginDir . $helper, 'plugin helper');
+    }
 
-$kernel = new StageKernel($wpRoot, $pluginDir, $runBase, $phpBin, $wpCli);
+    $kernelFiles = [
+        '/includes/kernel/StageInterface.php',
+        '/includes/kernel/StageResult.php',
+        '/includes/kernel/RunLogger.php',
+        '/includes/kernel/stages/Stage02.php',
+        '/includes/kernel/stages/Stage03.php',
+        '/includes/kernel/stages/Stage04.php',
+        '/includes/kernel/stages/Stage06.php',
+        '/includes/kernel/StageKernel.php',
+    ];
+    foreach ($kernelFiles as $file) {
+        compu_run_require_file($pluginDir . $file, 'kernel file');
+    }
 
-$contextOptions = [];
-$map = [
-    'dry_run' => 'DRY_RUN',
-    'require_term' => 'REQUIRE_TERM',
-    'limit' => 'LIMIT',
-    'offset' => 'OFFSET',
-    'from' => 'SUBSET_FROM',
-    'rows' => 'SUBSET_ROWS',
-    'subset_from' => 'SUBSET_FROM',
-    'subset_rows' => 'SUBSET_ROWS',
-    'csv' => 'CSV_SRC',
-    'source' => 'CSV_SRC',
-    'source_master' => 'SOURCE_MASTER',
-    'sample600' => 'SAMPLE600',
-    'run_dir' => 'RUN_DIR',
-    'run_id' => 'RUN_ID',
-];
+    $stageScripts = [
+        '/includes/stages/02-normalize.php',
+        '/includes/stages/03-validate.php',
+        '/includes/stages/04-resolve-map.php',
+    ];
+    foreach ($stageScripts as $script) {
+        compu_run_require_file($pluginDir . $script, 'stage script');
+    }
+}
 
-foreach ($map as $optionKey => $contextKey) {
-    if (isset($options[$optionKey])) {
+function compu_run_prepare_context(array $options, string $runId, ?string $csvPath): array
+{
+    $context = [
+        'RUN_ID' => $runId,
+        'RUN_DB_ID' => (int) $runId,
+        'DRY_RUN' => 0,
+    ];
+
+    if (isset($options['dry_run'])) {
+        $context['DRY_RUN'] = (int) ((int) $options['dry_run'] !== 0);
+    }
+
+    $map = [
+        'require_term' => 'REQUIRE_TERM',
+        'limit' => 'LIMIT',
+        'offset' => 'OFFSET',
+        'from' => 'SUBSET_FROM',
+        'rows' => 'SUBSET_ROWS',
+        'subset_from' => 'SUBSET_FROM',
+        'subset_rows' => 'SUBSET_ROWS',
+        'sample600' => 'SAMPLE600',
+        'run_dir' => 'RUN_DIR',
+    ];
+
+    foreach ($map as $optionKey => $contextKey) {
+        if (!array_key_exists($optionKey, $options)) {
+            continue;
+        }
         $value = $options[$optionKey];
-        if (in_array($contextKey, ['DRY_RUN', 'REQUIRE_TERM', 'LIMIT', 'OFFSET', 'SUBSET_FROM', 'SUBSET_ROWS', 'SAMPLE600'], true)) {
-            $value = (int) $value;
+        if (in_array($contextKey, ['REQUIRE_TERM', 'LIMIT', 'OFFSET', 'SUBSET_FROM', 'SUBSET_ROWS', 'SAMPLE600'], true)) {
+            $context[$contextKey] = (int) $value;
+        } else {
+            $context[$contextKey] = rtrim((string) $value, DIRECTORY_SEPARATOR);
         }
-        $contextOptions[$contextKey] = $value;
+    }
+
+    if ($csvPath !== null && $csvPath !== '') {
+        $context['CSV_SRC'] = $csvPath;
+    }
+
+    if (!empty($options['source_master'])) {
+        $context['SOURCE_MASTER'] = $options['source_master'];
+    }
+
+    return $context;
+}
+
+function compu_run_append_runlog(string $runDir, string $message): void
+{
+    $runDir = rtrim($runDir, DIRECTORY_SEPARATOR);
+    if ($runDir === '') {
+        return;
+    }
+    $logDir = $runDir . DIRECTORY_SEPARATOR . 'logs';
+    if (!is_dir($logDir)) {
+        @mkdir($logDir, 0775, true);
+    }
+    $logPath = $logDir . DIRECTORY_SEPARATOR . 'run.log';
+    $record = json_encode([
+        'ts' => gmdate('c'),
+        'stage' => 'RUN',
+        'level' => 'ERROR',
+        'msg' => $message,
+    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    if ($record !== false) {
+        file_put_contents($logPath, $record . "\n", FILE_APPEND);
     }
 }
 
-$contextOptions['CSV_SRC'] = $contextOptions['CSV_SRC'] ?? ($options['csv_src'] ?? null);
-if ($contextOptions['CSV_SRC'] === null) {
-    unset($contextOptions['CSV_SRC']);
-}
+function compu_run_main(): void
+{
+    $argv = $_SERVER['argv'] ?? [];
+    $options = compu_run_parse_args($argv);
 
-fwrite(STDOUT, '[compu-run] stages=' . implode(',', $stages) . "\n");
+    if (!empty($options['help'])) {
+        compu_run_exit(0, compu_run_help_text());
+    }
+
+    $stageSpec = $options['stages'] ?? '02..06';
+    $stages = compu_run_expand_stages($stageSpec);
+    if (empty($stages)) {
+        compu_run_exit(2, 'Invalid --stages specification. Allowed values: 02..06 or a comma-separated subset of 02,03,04,06.');
+    }
+
+    $wpRoot = rtrim($options['wp_root'] ?? getenv('WP_ROOT') ?: __DIR__, DIRECTORY_SEPARATOR);
+    if ($wpRoot === '' || !is_dir($wpRoot)) {
+        compu_run_exit(2, "Invalid --wp-root path: {$wpRoot}");
+    }
+
+    $wpLoad = $wpRoot . DIRECTORY_SEPARATOR . 'wp-load.php';
+    if (!is_file($wpLoad)) {
+        compu_run_exit(2, "Cannot locate wp-load.php at {$wpLoad}");
+    }
+
+    $pluginDirInput = $options['plugin_dir'] ?? getenv('PLUGIN_DIR') ?: ($wpRoot . '/wp-content/plugins/compu-import-lego');
+    $pluginDir = compu_run_resolve_plugin_dir($pluginDirInput);
+    if ($pluginDir === '' || !is_dir($pluginDir)) {
+        compu_run_exit(2, "Plugin directory not found: {$pluginDirInput}");
+    }
+
+    $runBase = $options['run_base'] ?? getenv('RUN_BASE') ?: ($wpRoot . '/wp-content/uploads/compu-import');
+    $runBase = rtrim($runBase, DIRECTORY_SEPARATOR);
+
+    $phpBin = (string) ($options['php_bin'] ?? PHP_BINARY);
+    $wpCli = (string) ($options['wp_cli'] ?? '/usr/local/bin/wp');
+
+    $csvPath = null;
+    if (!empty($options['csv'])) {
+        $csvCandidate = (string) $options['csv'];
+        if (!is_file($csvCandidate)) {
+            compu_run_exit(2, "CSV file not found: {$csvCandidate}");
+        }
+        $resolved = realpath($csvCandidate);
+        $csvPath = $resolved ?: $csvCandidate;
+    }
+
+    require_once $wpLoad;
+
+    if (!defined('COMPU_IMPORT_UPLOAD_SUBDIR')) {
+        define('COMPU_IMPORT_UPLOAD_SUBDIR', 'compu-import');
+    }
+    if (!defined('COMPU_IMPORT_DEFAULT_CSV')) {
+        define('COMPU_IMPORT_DEFAULT_CSV', $csvPath ?? '');
+    }
+
+    compu_run_require_plugin_bootstrap($pluginDir);
+
+    if (!class_exists(StageKernel::class)) {
+        compu_run_exit(2, 'StageKernel class is not available after loading plugin files.');
+    }
+
+    $stage06Path = $pluginDir . '/includes/stages/06-products.php';
+    if (!is_file($stage06Path)) {
+        compu_run_exit(2, "Required stage script missing: {$stage06Path}");
+    }
+
+    $runId = compu_run_normalize_run_id($options['run_id'] ?? null);
+    $contextOptions = compu_run_prepare_context($options, $runId, $csvPath);
+    $runDirHint = $contextOptions['RUN_DIR'] ?? ($runBase . DIRECTORY_SEPARATOR . 'run-' . $runId);
+
+    $kernel = new StageKernel($wpRoot, $pluginDir, $runBase, $phpBin, $wpCli);
+
+    compu_run_info('stages=' . implode(',', $stages));
+
+    try {
+        $result = $kernel->run($stages, $contextOptions);
+    } catch (Throwable $e) {
+        $message = 'Kernel execution failed: ' . $e->getMessage();
+        compu_run_append_runlog($runDirHint, $message);
+        compu_run_exit(2, $message);
+    }
+
+    $context = is_array($result['context'] ?? null) ? $result['context'] : [];
+    $runDir = isset($context['RUN_DIR']) ? (string) $context['RUN_DIR'] : $runDirHint;
+    $runIdOut = isset($context['RUN_ID']) ? (string) $context['RUN_ID'] : $runId;
+
+    if ($runIdOut !== '') {
+        compu_run_info('run_id=' . $runIdOut);
+    }
+    if ($runDir !== '') {
+        compu_run_info('run_dir=' . $runDir);
+    }
+    if (!empty($result['summary_path'])) {
+        compu_run_info('summary=' . $result['summary_path']);
+    }
+
+    $status = strtolower((string) ($result['status'] ?? ''));
+    $statusDetail = strtolower((string) ($result['status_detail'] ?? ($result['status_legacy'] ?? '')));
+
+    $finalStatus = $status !== '' ? $status : ($statusDetail === 'error' ? 'error' : 'ok');
+
+    if ($finalStatus === 'error') {
+        $detailText = $statusDetail !== '' ? strtoupper($statusDetail) : 'ERROR';
+        compu_run_exit(2, 'One or more stages failed (status ' . $detailText . ')');
+    }
+
+    $detailText = $statusDetail !== '' ? strtoupper($statusDetail) : 'OK';
+    compu_run_exit(0, 'Run completed with status ' . $detailText);
+}
 
 try {
-    $result = $kernel->run($stages, $contextOptions);
+    compu_run_main();
 } catch (Throwable $e) {
-    compu_run_exit(3, 'Kernel execution failed: ' . $e->getMessage());
+    compu_run_exit(2, 'Fatal error: ' . $e->getMessage());
 }
-
-$summary = $result['summary'] ?? [];
-$runId = $summary['run_id'] ?? ($result['context']['RUN_ID'] ?? 'unknown');
-$runDir = $result['context']['RUN_DIR'] ?? '';
-$summaryPath = $result['summary_path'] ?? '';
-$status = $result['status'] ?? 'ERROR';
-
-fwrite(STDOUT, '[compu-run] run_id=' . $runId . "\n");
-if ($runDir !== '') {
-    fwrite(STDOUT, '[compu-run] run_dir=' . $runDir . "\n");
-}
-if ($summaryPath !== '') {
-    fwrite(STDOUT, '[compu-run] summary=' . $summaryPath . "\n");
-}
-
-if ($status === 'ERROR') {
-    compu_run_exit(3, 'One or more stages failed');
-}
-
-compu_run_exit(0, 'Run completed with status ' . $status);

--- a/htdocs/wp-load.php
+++ b/htdocs/wp-load.php
@@ -31,6 +31,78 @@ if (!function_exists('wp_upload_dir')) {
     }
 }
 
+if (!function_exists('wp_mkdir_p')) {
+    function wp_mkdir_p(string $path): bool
+    {
+        if (is_dir($path)) {
+            return true;
+        }
+        return (bool) @mkdir($path, 0775, true);
+    }
+}
+
+if (!function_exists('current_time')) {
+    function current_time(string $type = 'mysql')
+    {
+        if ($type === 'timestamp') {
+            return time();
+        }
+        return gmdate('Y-m-d H:i:s');
+    }
+}
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data, int $options = 0, int $depth = 512)
+    {
+        return json_encode($data, $options | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES, $depth);
+    }
+}
+
+if (!function_exists('add_action')) {
+    function add_action(string $hook, callable $callback, int $priority = 10, int $acceptedArgs = 1): void
+    {
+        // No-op stub for CLI context.
+    }
+}
+
+if (!function_exists('do_action')) {
+    function do_action(string $hook, ...$args): void
+    {
+        // No-op stub for CLI context.
+    }
+}
+
+if (!function_exists('apply_filters')) {
+    function apply_filters(string $hook, $value)
+    {
+        return $value;
+    }
+}
+
+if (!class_exists('WP_Error')) {
+    class WP_Error
+    {
+        /** @var string */
+        public $code;
+
+        /** @var string */
+        public $message;
+
+        public function __construct(string $code = '', string $message = '')
+        {
+            $this->code = $code;
+            $this->message = $message;
+        }
+    }
+}
+
+if (!function_exists('is_wp_error')) {
+    function is_wp_error($thing): bool
+    {
+        return $thing instanceof WP_Error;
+    }
+}
+
 if (!class_exists('wpdb')) {
     class wpdb
     {
@@ -70,9 +142,3 @@ if (!isset($wpdb) || !($wpdb instanceof wpdb)) {
     $wpdb = new wpdb();
 }
 
-if (!function_exists('compu_import_now')) {
-    function compu_import_now(): string
-    {
-        return gmdate('Y-m-d H:i:s');
-    }
-}

--- a/server-mirror/compu-import-lego/includes/kernel/StageKernel.php
+++ b/server-mirror/compu-import-lego/includes/kernel/StageKernel.php
@@ -126,8 +126,13 @@ class StageKernel
         ]);
         $logger->close();
 
+        $statusDetail = strtolower($overallStatus);
+        $statusFlag = $overallStatus === StageResult::STATUS_ERROR ? 'error' : 'ok';
+
         return [
-            'status' => $overallStatus,
+            'status' => $statusFlag,
+            'status_detail' => $statusDetail,
+            'status_legacy' => $overallStatus,
             'summary' => $summary,
             'summary_path' => $summaryPath,
             'context' => $context,

--- a/server-mirror/compu-import-lego/includes/kernel/stages/Stage02.php
+++ b/server-mirror/compu-import-lego/includes/kernel/stages/Stage02.php
@@ -127,7 +127,7 @@ class Stage02 implements StageInterface
         if (($handle = fopen($file, 'r')) === false) {
             return 0;
         }
-        while (($row = fgetcsv($handle)) !== false) {
+        while (($row = fgetcsv($handle, 0, ',', '"', '\\')) !== false) {
             $count++;
         }
         fclose($handle);

--- a/server-mirror/compu-import-lego/includes/kernel/stages/Stage04.php
+++ b/server-mirror/compu-import-lego/includes/kernel/stages/Stage04.php
@@ -128,7 +128,7 @@ class Stage04 implements StageInterface
             return 0;
         }
         $count = 0;
-        while (($row = fgetcsv($fh)) !== false) {
+        while (($row = fgetcsv($fh, 0, ',', '"', '\\')) !== false) {
             $count++;
         }
         fclose($fh);

--- a/server-mirror/compu-import-lego/includes/stages/02-normalize.php
+++ b/server-mirror/compu-import-lego/includes/stages/02-normalize.php
@@ -51,7 +51,7 @@ class Compu_Stage_Normalize {
       $this->cli_error('No se pudieron crear los archivos de salida.');
     }
 
-    fputcsv($csvHandle, $normalizedHead);
+    fputcsv($csvHandle, $normalizedHead, ',', '"', '\\');
 
     while (($row = fgetcsv($handle, 0, $delimiter, '"', '\\')) !== false) {
       if ($this->isEmptyRow($row)) {
@@ -76,7 +76,7 @@ class Compu_Stage_Normalize {
       }
 
       fwrite($jsonHandle, $this->encodeJsonLine($assoc));
-      fputcsv($csvHandle, $csvRow);
+      fputcsv($csvHandle, $csvRow, ',', '"', '\\');
     }
 
     fclose($handle);
@@ -217,7 +217,7 @@ class Compu_Stage_Normalize {
     foreach ($meta as $index => &$item) {
       $item['normalized'] = $unique[$index];
       if ($item['is_sku']) {
-        $item['normalized'] = 'SKU';
+        $item['normalized'] = 'sku';
       }
     }
     unset($item);

--- a/tests/cli-smoke.md
+++ b/tests/cli-smoke.md
@@ -1,0 +1,116 @@
+# CLI smoke test transcript
+
+## Environment
+- Root: `/workspace/compustar-project/htdocs`
+- Plugin: `/workspace/compustar-project/server-mirror/compu-import-lego`
+- CSV: `/workspace/compustar-project/data/cli-smoke-products.csv`
+- Runner wrapper: `/workspace/compustar-project/htdocs/compu-run-cli.php`
+
+## Check 1 — `--help`
+- Command: `php -d display_errors=1 /workspace/compustar-project/htdocs/compu-run-cli.php --help`
+- Exit code: `0`
+- STDERR (first 20 lines): _empty_
+
+## Check 2 — invalid stages
+- Command: `php -d display_errors=1 /workspace/compustar-project/htdocs/compu-run-cli.php --stages=99`
+- Exit code: `2`
+- STDERR (first 20 lines):
+  ```
+  Invalid --stages specification. Allowed values: 02..06 or a comma-separated subset of 02,03,04,06.
+  ```
+
+## Check 3 — dry-run structure
+- Command: `php -d display_errors=1 /workspace/compustar-project/htdocs/compu-run-cli.php --stages=02,03 --dry-run=1 --csv=/workspace/compustar-project/data/cli-smoke-products.csv --wp-root=/workspace/compustar-project/htdocs --plugin-dir=/workspace/compustar-project/server-mirror/compu-import-lego`
+- Exit code: `0`
+- STDERR (first 20 lines): _empty_
+- RUN_DIR: `/workspace/compustar-project/htdocs/wp-content/uploads/compu-import/run-20251007205337448`
+- `tail -n 20` of `logs/run.log`:
+  ```
+{"ts":"2025-10-07T20:53:37+00:00","stage":"RUN","level":"INFO","msg":"Run started","run_id":"20251007205337448","stages":["02","03"]}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"02","level":"INFO","msg":"Starting stage","title":"Normalize source CSV"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"02","level":"METRIC","metrics":{"dry_run":1,"duration_ms":0}}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"02","level":"INFO","notes":"Dry-run: skipped stage execution"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"02","level":"WARN","msg":"Expected output artifact missing","artifact":"normalized.jsonl"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"02","level":"WARN","msg":"Expected output artifact missing","artifact":"normalized.csv"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"02","level":"DONE","status":"WARN"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"03","level":"INFO","msg":"Starting stage","title":"Validate normalized data"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"03","level":"WARN","msg":"Missing input artifact","artifact":"normalized.jsonl"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"03","level":"METRIC","metrics":{"dry_run":1,"duration_ms":0}}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"03","level":"INFO","notes":"Dry-run: skipped stage execution"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"03","level":"WARN","msg":"Expected output artifact missing","artifact":"validated.jsonl"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"03","level":"DONE","status":"WARN"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"RUN","level":"INFO","msg":"Run finished","status":"WARN","summary":"/workspace/compustar-project/htdocs/wp-content/uploads/compu-import/run-20251007205337448/final/summary.json"}
+  ```
+- `tail -n 20` of `logs/stage-02.log`:
+  ```
+{"ts":"2025-10-07T20:53:37+00:00","stage":"02","level":"INFO","msg":"Starting stage","title":"Normalize source CSV"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"02","level":"METRIC","metrics":{"dry_run":1,"duration_ms":0}}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"02","level":"INFO","notes":"Dry-run: skipped stage execution"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"02","level":"WARN","msg":"Expected output artifact missing","artifact":"normalized.jsonl"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"02","level":"WARN","msg":"Expected output artifact missing","artifact":"normalized.csv"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"02","level":"DONE","status":"WARN"}
+  ```
+- `tail -n 20` of `logs/stage-03.log`:
+  ```
+{"ts":"2025-10-07T20:53:37+00:00","stage":"03","level":"INFO","msg":"Starting stage","title":"Validate normalized data"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"03","level":"WARN","msg":"Missing input artifact","artifact":"normalized.jsonl"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"03","level":"METRIC","metrics":{"dry_run":1,"duration_ms":0}}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"03","level":"INFO","notes":"Dry-run: skipped stage execution"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"03","level":"WARN","msg":"Expected output artifact missing","artifact":"validated.jsonl"}
+{"ts":"2025-10-07T20:53:37+00:00","stage":"03","level":"DONE","status":"WARN"}
+  ```
+
+## Check 4 — staged run (02..06)
+- Command: `php -d display_errors=1 /workspace/compustar-project/htdocs/compu-run-cli.php --stages=02..06 --from=1000 --rows=201 --dry-run=0 --require-term=1 --csv=/workspace/compustar-project/data/cli-smoke-products.csv --wp-root=/workspace/compustar-project/htdocs --plugin-dir=/workspace/compustar-project/server-mirror/compu-import-lego`
+- Exit code: `0`
+- STDERR (first 20 lines): _empty_
+- RUN_DIR: `/workspace/compustar-project/htdocs/wp-content/uploads/compu-import/run-20251007205338152`
+- `tail -n 20` of `logs/run.log`:
+  ```
+{"ts":"2025-10-07T20:53:38+00:00","stage":"RUN","level":"INFO","msg":"Run started","run_id":"20251007205338152","stages":["02","03","04","06"]}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"02","level":"INFO","msg":"Starting stage","title":"Normalize source CSV"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"02","level":"METRIC","metrics":{"duration_ms":31,"rows_in":5,"rows_out":5,"skipped":0,"missing_sku":0,"missing_lvl1_id":0,"missing_lvl2_id":0}}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"02","level":"DONE","status":"OK"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"03","level":"INFO","msg":"Starting stage","title":"Validate normalized data"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"03","level":"METRIC","metrics":{"duration_ms":0,"rows_in":5,"rows_out":5,"skipped":0,"missing_sku":0,"missing_lvl1_id":0,"missing_lvl2_id":0}}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"03","level":"DONE","status":"OK"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"04","level":"INFO","msg":"Starting stage","title":"Resolve category mapping"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"04","level":"METRIC","metrics":{"duration_ms":0,"rows_in":5,"rows_out":5,"skipped":0,"unmapped":5}}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"04","level":"DONE","status":"WARN"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"06","level":"INFO","msg":"Starting stage","title":"Products simulation writer"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"06","level":"METRIC","metrics":{"rows_in":5,"rows_out":0,"skipped":0,"duration_ms":91}}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"06","level":"WARN","msg":"Expected output artifact missing","artifact":"final/imported.csv"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"06","level":"WARN","msg":"Expected output artifact missing","artifact":"final/updated.csv"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"06","level":"WARN","msg":"Expected output artifact missing","artifact":"final/skipped.csv"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"06","level":"DONE","status":"OK"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"RUN","level":"INFO","msg":"Run finished","status":"WARN","summary":"/workspace/compustar-project/htdocs/wp-content/uploads/compu-import/run-20251007205338152/final/summary.json"}
+  ```
+- `tail -n 20` of `logs/stage-02.log`:
+  ```
+{"ts":"2025-10-07T20:53:38+00:00","stage":"02","level":"INFO","msg":"Starting stage","title":"Normalize source CSV"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"02","level":"METRIC","metrics":{"duration_ms":31,"rows_in":5,"rows_out":5,"skipped":0,"missing_sku":0,"missing_lvl1_id":0,"missing_lvl2_id":0}}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"02","level":"DONE","status":"OK"}
+  ```
+- `tail -n 20` of `logs/stage-03.log`:
+  ```
+{"ts":"2025-10-07T20:53:38+00:00","stage":"03","level":"INFO","msg":"Starting stage","title":"Validate normalized data"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"03","level":"METRIC","metrics":{"duration_ms":0,"rows_in":5,"rows_out":5,"skipped":0,"missing_sku":0,"missing_lvl1_id":0,"missing_lvl2_id":0}}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"03","level":"DONE","status":"OK"}
+  ```
+- `tail -n 20` of `logs/stage-04.log`:
+  ```
+{"ts":"2025-10-07T20:53:38+00:00","stage":"04","level":"INFO","msg":"Starting stage","title":"Resolve category mapping"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"04","level":"METRIC","metrics":{"duration_ms":0,"rows_in":5,"rows_out":5,"skipped":0,"unmapped":5}}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"04","level":"DONE","status":"WARN"}
+  ```
+- `tail -n 20` of `logs/stage-06.log`:
+  ```
+{"ts":"2025-10-07T20:53:38+00:00","stage":"06","level":"INFO","msg":"Starting stage","title":"Products simulation writer"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"06","level":"METRIC","metrics":{"rows_in":5,"rows_out":0,"skipped":0,"duration_ms":91}}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"06","level":"WARN","msg":"Expected output artifact missing","artifact":"final/imported.csv"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"06","level":"WARN","msg":"Expected output artifact missing","artifact":"final/updated.csv"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"06","level":"WARN","msg":"Expected output artifact missing","artifact":"final/skipped.csv"}
+{"ts":"2025-10-07T20:53:38+00:00","stage":"06","level":"DONE","status":"OK"}
+  ```
+
+_All timestamps are UTC._

--- a/tests/run-cli-smoke.sh
+++ b/tests/run-cli-smoke.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DEFAULT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/htdocs"
+ROOT="${ROOT_OVERRIDE:-$ROOT_DEFAULT}"
+CLI="$ROOT/compu-run-cli.php"
+PHP_BIN="${PHP_BIN:-php}"
+CSV_DEFAULT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/data/cli-smoke-products.csv"
+CSV_PATH="${CSV_OVERRIDE:-$CSV_DEFAULT}"
+PLUGIN_DEFAULT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/server-mirror/compu-import-lego"
+PLUGIN_DIR="${PLUGIN_OVERRIDE:-$PLUGIN_DEFAULT}"
+TMPDIR="${TMPDIR:-/tmp}"
+OUT_PREFIX="$TMPDIR/cli-smoke"
+
+mkdir -p "$ROOT/wp-content/uploads"
+
+printf 'Running CLI smoke tests with ROOT=%s\n' "$ROOT"
+
+# Check 1 — help
+HELP_OUT="$OUT_PREFIX.help.out"
+HELP_ERR="$OUT_PREFIX.help.err"
+set +e
+"$PHP_BIN" -d display_errors=1 "$CLI" --help >"$HELP_OUT" 2>"$HELP_ERR"
+status=$?
+set -e
+if [[ $status -ne 0 ]]; then
+  echo "Check 1 failed with exit $status" >&2
+  exit 1
+fi
+if ! grep -q 'Compu Import unified runner' "$HELP_OUT"; then
+  echo "Check 1 output missing header" >&2
+  exit 1
+fi
+
+# Check 2 — invalid stages
+ST99_OUT="$OUT_PREFIX.st99.out"
+ST99_ERR="$OUT_PREFIX.st99.err"
+set +e
+"$PHP_BIN" -d display_errors=1 "$CLI" --stages=99 >"$ST99_OUT" 2>"$ST99_ERR"
+status=$?
+set -e
+if [[ $status -ne 2 ]]; then
+  echo "Check 2 expected exit 2, got $status" >&2
+  exit 1
+fi
+if ! grep -q 'Invalid --stages specification' "$ST99_ERR"; then
+  echo "Check 2 missing invalid stages message" >&2
+  exit 1
+fi
+
+# Check 3 — dry-run structure
+DRY_OUT="$OUT_PREFIX.dry.out"
+DRY_ERR="$OUT_PREFIX.dry.err"
+set +e
+"$PHP_BIN" -d display_errors=1 "$CLI" \
+  --stages=02,03 --dry-run=1 \
+  --csv="$CSV_PATH" --wp-root="$ROOT" --plugin-dir="$PLUGIN_DIR" \
+  >"$DRY_OUT" 2>"$DRY_ERR"
+status=$?
+set -e
+if [[ $status -ne 0 ]]; then
+  echo "Check 3 expected exit 0, got $status" >&2
+  exit 1
+fi
+RUN_DIR_DRY=$(ls -1dt "$ROOT"/wp-content/uploads/compu-import/run-* 2>/dev/null | head -1 || true)
+if [[ -z "$RUN_DIR_DRY" ]]; then
+  echo "Check 3 could not locate run directory" >&2
+  exit 1
+fi
+if [[ ! -d "$RUN_DIR_DRY/logs" ]]; then
+  echo "Check 3 missing logs directory" >&2
+  exit 1
+fi
+if [[ ! -f "$RUN_DIR_DRY/logs/run.log" ]]; then
+  echo "Check 3 missing run.log" >&2
+  exit 1
+fi
+if [[ ! -f "$RUN_DIR_DRY/source.csv" && ! -L "$RUN_DIR_DRY/source.csv" ]]; then
+  echo "Check 3 missing source.csv link or file" >&2
+  exit 1
+fi
+printf 'Dry-run run dir: %s\n' "$RUN_DIR_DRY"
+
+# Check 4 — real subset run
+REAL_OUT="$OUT_PREFIX.real.out"
+REAL_ERR="$OUT_PREFIX.real.err"
+set +e
+"$PHP_BIN" -d display_errors=1 "$CLI" \
+  --stages=02..06 \
+  --from=1000 --rows=201 --dry-run=0 --require-term=1 \
+  --csv="$CSV_PATH" --wp-root="$ROOT" --plugin-dir="$PLUGIN_DIR" \
+  >"$REAL_OUT" 2>"$REAL_ERR"
+status=$?
+set -e
+if [[ $status -ne 0 ]]; then
+  echo "Check 4 expected exit 0, got $status" >&2
+  exit 1
+fi
+RUN_DIR_REAL=$(ls -1dt "$ROOT"/wp-content/uploads/compu-import/run-* 2>/dev/null | head -1 || true)
+if [[ -z "$RUN_DIR_REAL" ]]; then
+  echo "Check 4 could not locate run directory" >&2
+  exit 1
+fi
+if [[ ! -f "$RUN_DIR_REAL/final/summary.json" ]]; then
+  echo "Check 4 missing summary.json" >&2
+  exit 1
+fi
+for stage in 02 03 04 06; do
+  if [[ ! -f "$RUN_DIR_REAL/logs/stage-$stage.log" ]]; then
+    echo "Check 4 missing log for stage $stage" >&2
+    exit 1
+  fi
+done
+printf 'Real run dir: %s\n' "$RUN_DIR_REAL"
+
+echo "CLI smoke tests completed successfully."


### PR DESCRIPTION
## Summary
- refactor `compu-run.php` to centralize exit handling, validate stages, bootstrap WordPress/plugin dependencies, and surface run/summary details
- add a CLI wrapper that seeds required WP constants before delegating to the runner
- extend WordPress stub helpers, stage kernel reporting, CSV handling, and add smoke test dataset/docs to cover CLI execution paths

## Testing
- `bash tests/run-cli-smoke.sh`


------
https://chatgpt.com/codex/tasks/task_b_68e5786bab688320834e60b495ed7ea6