### PR TITLE
Add Stage 01 loader and guard StageKernel permissions

### DIFF
--- a/server-mirror/compu-import-lego/includes/kernel/StageKernel.php
+++ b/server-mirror/compu-import-lego/includes/kernel/StageKernel.php
@@ -262,7 +262,7 @@ class StageKernel
     private function buildStageDefinitions(): void
     {
         $this->stageDefinitions = [];
-        $stage01 = new Stage01();
+        $stage01 = new Stage01($this->pluginDir . '/includes/stages/01-fetch.php');
         $stage02 = new Stage02();
         $stage03 = new Stage03();
         $stage04 = new Stage04();
@@ -366,7 +366,9 @@ class StageKernel
         if ($group === false) {
             return;
         }
-        @chgrp($path, 'compustar');
+        if (function_exists('chgrp')) {
+            @chgrp($path, 'compustar');
+        }
     }
 
     private function exportContextEnv(array $context): void


### PR DESCRIPTION
## Summary
- load Stage 01 from the plugin directory when building stage definitions
- lazily bootstrap the fetch stage wrapper so stage 01 can run outside of WordPress bootstrap
- guard chgrp() calls in StageKernel so environments without the function do not emit warnings

## Testing
- php -d display_errors=1 htdocs/compu-run-cli.php --help
- php -d display_errors=1 htdocs/compu-run-cli.php --stages=99
- php -d display_errors=1 htdocs/compu-run-cli.php --stages=01,02,03 --dry-run=1 --csv="/workspace/compustar-project/htdocs/ProductosHora.csv" --wp-root="/workspace/compustar-project/htdocs" --plugin-dir="/workspace/compustar-project/htdocs/wp-content/plugins/compu-import-lego"
- php -d display_errors=1 htdocs/compu-run-cli.php --stages=01..06 --from=1000 --rows=201 --dry-run=0 --require-term=1 --csv="/workspace/compustar-project/htdocs/ProductosHora.csv" --wp-root="/workspace/compustar-project/htdocs" --plugin-dir="/workspace/compustar-project/htdocs/wp-content/plugins/compu-import-lego"

------
https://chatgpt.com/codex/tasks/task_b_68e5c46f56b48320b162b1e34a88c0af