### PR TITLE
Enable real WooCommerce writer in stages 10 and 11

### DIFF
--- a/python/stage10_import.py
+++ b/python/stage10_import.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 import argparse
 import json
-import random
+import os
+import shlex
+import subprocess
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple
 
@@ -15,6 +17,268 @@ from pipeline_utils import (
 
 
 DEFAULT_SUMMARY_KEYS = ("stage_10",)
+
+
+class WPCLIError(RuntimeError):
+    """Raised when a WP-CLI command fails."""
+
+
+class WooClient:
+    def __init__(
+        self,
+        wp_path: str,
+        wp_args: str,
+        log,
+        write_enabled: bool,
+    ) -> None:
+        self.wp_path = wp_path or "wp"
+        self.wp_args = shlex.split(wp_args) if wp_args else []
+        self.log = log
+        self.write_enabled = write_enabled
+
+    def _build_cmd(self, args: Iterable[str]) -> List[str]:
+        return [self.wp_path, *self.wp_args, *list(args)]
+
+    def _format_cmd(self, cmd: Iterable[str]) -> str:
+        return " ".join(shlex.quote(part) for part in cmd)
+
+    def run(self, args: Iterable[str], *, write: bool = False, check: bool = True) -> subprocess.CompletedProcess:
+        cmd = self._build_cmd(args)
+        if write and not self.write_enabled:
+            if self.log is not None:
+                self.log.write(f"[dry-run] {self._format_cmd(cmd)}\n")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True)
+        except FileNotFoundError as exc:
+            raise WPCLIError(f"wp_cli_not_found:{exc}") from exc
+        if check and result.returncode != 0:
+            message = result.stderr.strip() or result.stdout.strip() or self._format_cmd(cmd)
+            raise WPCLIError(message)
+        return result
+
+    def find_product_id(self, sku: str) -> Optional[int]:
+        if not sku:
+            return None
+        result = self.run(
+            [
+                "post",
+                "list",
+                "--post_type=product",
+                "--meta_key=_sku",
+                f"--meta_value={sku}",
+                "--fields=ID",
+                "--format=ids",
+            ],
+            write=False,
+        )
+        output = (result.stdout or "").strip()
+        if not output:
+            return None
+        for part in output.split():
+            try:
+                product_id = int(part.strip())
+            except (TypeError, ValueError):
+                continue
+            if product_id > 0:
+                return product_id
+        return None
+
+    def get_post_field(self, product_id: int, field: str) -> str:
+        result = self.run(
+            ["post", "get", str(product_id), f"--field={field}"],
+            write=False,
+            check=False,
+        )
+        if result.returncode != 0:
+            return ""
+        return (result.stdout or "").strip()
+
+    def get_post_meta(self, product_id: int, key: str) -> str:
+        result = self.run(
+            ["post", "meta", "get", str(product_id), key],
+            write=False,
+            check=False,
+        )
+        if result.returncode != 0:
+            return ""
+        return (result.stdout or "").strip()
+
+    def update_post_meta(self, product_id: int, key: str, value: str) -> None:
+        self.run(
+            ["post", "meta", "update", str(product_id), key, value],
+            write=True,
+        )
+
+    def post_update(self, product_id: int, **fields: str) -> None:
+        args = ["post", "update", str(product_id)]
+        for key, value in fields.items():
+            args.append(f"--{key}={value}")
+        self.run(args, write=True)
+
+    def post_create(self, **fields: str) -> int:
+        args = ["post", "create", "--post_type=product", "--post_status=publish", "--porcelain"]
+        for key, value in fields.items():
+            args.append(f"--{key}={value}")
+        result = self.run(args, write=True)
+        output = (result.stdout or "").strip()
+        try:
+            product_id = int(output)
+        except (TypeError, ValueError):
+            raise WPCLIError(f"post create → respuesta inesperada: {output}")
+        if product_id <= 0:
+            raise WPCLIError(f"post create → ID inválido: {output}")
+        return product_id
+
+    def product_has_image(self, product_id: int) -> bool:
+        thumbnail_id = self.get_post_meta(product_id, "_thumbnail_id")
+        return bool(thumbnail_id)
+
+    def product_has_description(self, product_id: int) -> bool:
+        content = self.get_post_field(product_id, "post_content")
+        return bool(content)
+
+    def ensure_brand(self, brand: str) -> None:
+        if not brand:
+            return
+        slug = slugify(brand)
+        result = self.run(
+            [
+                "term",
+                "create",
+                "product_brand",
+                brand,
+                f"--slug={slug}",
+            ],
+            write=True,
+            check=False,
+        )
+        if result.returncode not in (0,):
+            message = (result.stderr or "").lower()
+            if "term already exists" not in message:
+                raise WPCLIError(result.stderr.strip() or result.stdout.strip() or "term create error")
+
+    def set_brand(self, product_id: int, brand: str) -> None:
+        if not brand:
+            return
+        self.ensure_brand(brand)
+        self.run(
+            [
+                "term",
+                "set",
+                "product_brand",
+                str(product_id),
+                brand,
+                "--by=name",
+            ],
+            write=True,
+        )
+
+    def set_category(self, product_id: int, category: str) -> None:
+        if not category:
+            return
+        args = ["term", "set", "product_cat", str(product_id), str(category)]
+        if str(category).isdigit():
+            args.append("--by=id")
+        self.run(args, write=True)
+
+    def import_image(self, product_id: int, source: str) -> None:
+        if not source:
+            return
+        self.run(
+            [
+                "media",
+                "import",
+                source,
+                "--featured_image",
+                f"--post_id={product_id}",
+                "--porcelain",
+            ],
+            write=True,
+        )
+
+    def get_terms(self, product_id: int, taxonomy: str) -> List[Dict[str, Any]]:
+        result = self.run(
+            [
+                "term",
+                "list",
+                taxonomy,
+                f"--object_id={product_id}",
+                "--fields=term_id,name,slug",
+                "--format=json",
+            ],
+            write=False,
+            check=False,
+        )
+        if result.returncode != 0:
+            return []
+        try:
+            data = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError:
+            return []
+        if isinstance(data, list):
+            return [item for item in data if isinstance(item, Mapping)]
+        return []
+
+
+def slugify(text: str) -> str:
+    normalized = str(text).strip().lower()
+    cleaned = []
+    for char in normalized:
+        if char.isalnum():
+            cleaned.append(char)
+        elif char in {" ", "-", "_", "."}:
+            cleaned.append("-" if char == " " else char)
+    slug = "".join(cleaned)
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    slug = slug.strip("-_.")
+    return slug or "marca"
+
+
+def extract_description(record: Mapping[str, Any]) -> str:
+    keys = (
+        "descripcion_html",
+        "description_html",
+        "descripcion",
+        "Descripcion",
+        "description",
+    )
+    for key in keys:
+        value = record.get(key)
+        if isinstance(value, str):
+            text = value.strip()
+            if text:
+                return text
+    return ""
+
+
+def extract_image_source(record: Mapping[str, Any]) -> str:
+    keys = (
+        "image_url",
+        "Imagen_Principal",
+        "image",
+        "imagen",
+        "image_path",
+        "image_local_path",
+    )
+    for key in keys:
+        value = record.get(key)
+        if isinstance(value, str):
+            text = value.strip()
+            if text:
+                return text
+    return ""
+
+
+def format_wp_error(exc: Exception) -> str:
+    message = str(exc).strip().replace("\r", " ").replace("\n", " ")
+    message = " ".join(message.split())
+    return f"wp_error:{message}" if message else "wp_error:unknown"
+
+
+def format_price(value: float) -> str:
+    return f"{float(value):.2f}"
 
 
 def to_bool(value: Any) -> bool:
@@ -175,6 +439,15 @@ def stage10(args: argparse.Namespace) -> None:
     dry_run = bool(args.dry_run)
     summary_paths = ensure_summary_paths(run_dir, args.summary)
 
+    env_writer = (args.writer or os.environ.get("IMPORT_WRITER") or os.environ.get("WRITER") or "sim").strip().lower()
+    writer = env_writer if env_writer in {"sim", "wp"} else "sim"
+    if writer == "wp" and dry_run and to_bool(os.environ.get("FORCE_WRITE")):
+        dry_run = False
+    wp_path = args.wp_path or os.environ.get("WP_PATH", "wp")
+    wp_args = args.wp_args or os.environ.get("WP_PATH_ARGS", "")
+    write_enabled = writer == "wp" and not dry_run
+    mode = "wp" if write_enabled else "simulation"
+
     ensure_parent_dir(log_path)
     ensure_parent_dir(report_path)
 
@@ -188,6 +461,9 @@ def stage10(args: argparse.Namespace) -> None:
         "updated": 0,
         "skipped": 0,
         "price_zero": 0,
+        "wp_errors": 0,
+        "mode": mode,
+        "writer": writer,
     }
 
     if not input_path.exists():
@@ -197,8 +473,14 @@ def stage10(args: argparse.Namespace) -> None:
     metrics["rows_total"] = len(records)
 
     with log_path.open("w", encoding="utf-8") as log:
-        log.write("== Stage 10: import (simulación)==\n")
+        log.write(f"== Stage 10: import (writer={writer})==\n")
         log.write(f"Dry-run={'yes' if dry_run else 'no'}\n")
+
+        woo_client = (
+            WooClient(wp_path, wp_args, log, write_enabled)
+            if writer == "wp"
+            else None
+        )
 
         for record in records:
             sku = str(record.get("sku"))
@@ -224,65 +506,134 @@ def stage10(args: argparse.Namespace) -> None:
             stock_total = stock_info["stock_total_mayoristas"]
 
             precio_objetivo = parse_float(record.get("price_16_final"), 0.0)
-            if precio_objetivo is None or not isinstance(precio_objetivo, (int, float)):
-                precio_objetivo = 0.0
             if not isinstance(precio_objetivo, (int, float)):
                 precio_objetivo = 0.0
 
-            existing, product_id = detect_existing(record)
-            current_price = parse_float(record.get("woo_regular_price"), 0.0)
-            current_stock = parse_int(record.get("woo_stock"), 0)
-
-            before: Dict[str, Any] = {}
-            if existing:
-                if product_id:
-                    before["product_id"] = product_id
-                if current_price:
-                    before["price"] = current_price
-                before["stock"] = current_stock
-                if record.get("woo_name"):
-                    before["name"] = record.get("woo_name")
-                if record.get("woo_category"):
-                    before["category"] = record.get("woo_category")
-                if record.get("woo_brand"):
-                    before["brand"] = record.get("woo_brand")
-
+            description_text = extract_description(record)
+            image_source = extract_image_source(record)
             weight = target_weight(record)
 
-            should_update_description = not has_description(record)
-            should_update_image = not has_image(record)
+            after_payload: Dict[str, Any] = {
+                "name": name,
+                "brand": brand,
+                "category": category,
+                "stock": stock_total,
+                "price": round(precio_objetivo, 2) if isinstance(precio_objetivo, (int, float)) else 0.0,
+                "update_price": False,
+                "set_description": False,
+                "set_image": False,
+                "weight": weight,
+                "stock_breakdown": {
+                    "syscom": stock_info["stock_syscom"],
+                    "mayoristas": stock_info["stock_mayoristas"],
+                },
+            }
+
+            if weight is None:
+                after_payload.pop("weight")
 
             entry: Dict[str, Any] = {
                 "sku": sku,
                 "stock_total_mayoristas": stock_total,
                 "precio_objetivo": round(precio_objetivo, 2) if isinstance(precio_objetivo, (int, float)) else 0.0,
-                "before": before if before else None,
-                "after": {
-                    "name": name,
-                    "brand": brand,
-                    "category": category,
-                    "stock": stock_total,
-                    "price": round(precio_objetivo, 2) if isinstance(precio_objetivo, (int, float)) else 0.0,
-                    "update_price": False,
-                    "set_description": should_update_description,
-                    "set_image": should_update_image,
-                    "weight": weight,
-                    "stock_breakdown": {
-                        "syscom": stock_info["stock_syscom"],
-                        "mayoristas": stock_info["stock_mayoristas"],
-                    },
-                },
+                "before": None,
+                "after": after_payload,
             }
 
-            if weight is None:
-                entry["after"].pop("weight")
+            before: Dict[str, Any] = {}
+            existing = False
+            product_id: Optional[int] = None
+            current_price = 0.0
+            current_stock = 0
+
+            if writer == "wp" and woo_client is not None:
+                try:
+                    product_id = woo_client.find_product_id(sku)
+                except WPCLIError as exc:
+                    entry["action"] = "skip"
+                    entry["reason"] = format_wp_error(exc)
+                    skipped.append(entry)
+                    metrics["skipped"] += 1
+                    metrics["wp_errors"] += 1
+                    log.write(f"{sku}: error consultando Woo → {exc}\n")
+                    continue
+                existing = product_id is not None
+                if existing and product_id:
+                    before["product_id"] = product_id
+                    existing_name = woo_client.get_post_field(product_id, "post_title")
+                    if existing_name:
+                        before["name"] = existing_name
+                    current_price = parse_float(woo_client.get_post_meta(product_id, "_regular_price"), 0.0)
+                    if current_price > 0:
+                        before["price"] = current_price
+                    current_stock = parse_int(woo_client.get_post_meta(product_id, "_stock"), 0)
+                    before["stock"] = current_stock
+                    brand_terms = woo_client.get_terms(product_id, "product_brand")
+                    if brand_terms:
+                        before_brand = brand_terms[0].get("name")
+                        if before_brand:
+                            before["brand"] = before_brand
+                    cat_terms = woo_client.get_terms(product_id, "product_cat")
+                    if cat_terms:
+                        before_cat = cat_terms[0].get("term_id") or cat_terms[0].get("name")
+                        if before_cat:
+                            before["category"] = before_cat
+                    has_desc = woo_client.product_has_description(product_id)
+                    has_img = woo_client.product_has_image(product_id)
+                else:
+                    has_desc = False
+                    has_img = False
+            else:
+                existing, product_id = detect_existing(record)
+                current_price = parse_float(record.get("woo_regular_price"), 0.0)
+                current_stock = parse_int(record.get("woo_stock"), 0)
+                if existing:
+                    if product_id:
+                        before["product_id"] = product_id
+                    if current_price:
+                        before["price"] = current_price
+                    before["stock"] = current_stock
+                    if record.get("woo_name"):
+                        before["name"] = record.get("woo_name")
+                    if record.get("woo_category"):
+                        before["category"] = record.get("woo_category")
+                    if record.get("woo_brand"):
+                        before["brand"] = record.get("woo_brand")
+                has_desc = has_description(record)
+                has_img = has_image(record)
+
+            if before:
+                entry["before"] = before
+
+            if writer == "wp":
+                should_update_description = bool(description_text) and not has_desc
+                should_update_image = bool(image_source) and not has_img
+            else:
+                should_update_description = not has_desc
+                should_update_image = not has_img
+
+            after_payload["set_description"] = should_update_description
+            after_payload["set_image"] = should_update_image
 
             if precio_objetivo <= 0:
                 metrics["price_zero"] += 1
                 entry["reason"] = "price_zero"
-                if existing:
+                if existing and product_id:
                     entry["action"] = "update_stock_zero_due_to_price_zero"
-                    entry["after"]["stock"] = 0
+                    after_payload["stock"] = 0
+                    if writer == "wp" and woo_client is not None:
+                        try:
+                            woo_client.update_post_meta(product_id, "_manage_stock", "yes")
+                            woo_client.update_post_meta(product_id, "_stock", "0")
+                            woo_client.update_post_meta(product_id, "_stock_status", "outofstock")
+                        except WPCLIError as exc:
+                            entry["action"] = "error"
+                            entry["reason"] = format_wp_error(exc)
+                            skipped.append(entry)
+                            metrics["skipped"] += 1
+                            metrics["wp_errors"] += 1
+                            log.write(f"{sku}: error WP price_zero → {exc}\n")
+                            continue
                     updated.append(entry)
                     metrics["updated"] += 1
                     log.write(
@@ -303,22 +654,92 @@ def stage10(args: argparse.Namespace) -> None:
                 log.write(f"{sku}: stock total 0 → no se crea/actualiza.\n")
                 continue
 
-            if existing:
+            if existing and product_id:
                 entry["action"] = "update"
-                if precio_objetivo > 0 and (
-                    current_price <= 0 or precio_objetivo < current_price
-                ):
-                    entry["after"]["update_price"] = True
-                else:
-                    entry["after"]["update_price"] = False
+                after_payload["update_price"] = bool(
+                    precio_objetivo > 0 and (
+                        current_price <= 0 or round(precio_objetivo, 2) != round(current_price, 2)
+                    )
+                )
+                if writer == "wp" and woo_client is not None:
+                    try:
+                        woo_client.update_post_meta(product_id, "_sku", sku)
+                        woo_client.update_post_meta(product_id, "_manage_stock", "yes")
+                        woo_client.update_post_meta(product_id, "_stock", str(stock_total))
+                        woo_client.update_post_meta(
+                            product_id,
+                            "_stock_status",
+                            "instock" if stock_total > 0 else "outofstock",
+                        )
+                        if precio_objetivo > 0:
+                            price_text = format_price(precio_objetivo)
+                            woo_client.update_post_meta(product_id, "_price", price_text)
+                            woo_client.update_post_meta(product_id, "_regular_price", price_text)
+                        if weight is not None:
+                            woo_client.update_post_meta(product_id, "_weight", str(weight))
+                        update_fields: Dict[str, str] = {}
+                        if name and before.get("name") != name:
+                            update_fields["post_title"] = name
+                        if should_update_description and description_text:
+                            update_fields["post_content"] = description_text
+                        if update_fields:
+                            woo_client.post_update(product_id, **update_fields)
+                        if brand and (not before.get("brand") or before.get("brand") != brand):
+                            woo_client.set_brand(product_id, brand)
+                        if category:
+                            woo_client.set_category(product_id, category)
+                        if should_update_image and image_source:
+                            woo_client.import_image(product_id, image_source)
+                    except WPCLIError as exc:
+                        entry["action"] = "error"
+                        entry["reason"] = format_wp_error(exc)
+                        skipped.append(entry)
+                        metrics["skipped"] += 1
+                        metrics["wp_errors"] += 1
+                        log.write(f"{sku}: error WP update → {exc}\n")
+                        continue
                 updated.append(entry)
                 metrics["updated"] += 1
                 log.write(
                     f"{sku}: update → stock={stock_total} precio={precio_objetivo}"
-                    f" update_price={entry['after']['update_price']}.\n"
+                    f" update_price={after_payload['update_price']}.\n"
                 )
             else:
                 entry["action"] = "create"
+                if writer == "wp" and woo_client is not None:
+                    try:
+                        create_fields: Dict[str, str] = {"post_title": name or sku}
+                        if should_update_description and description_text:
+                            create_fields["post_content"] = description_text
+                        product_id = woo_client.post_create(**create_fields)
+                        woo_client.update_post_meta(product_id, "_sku", sku)
+                        woo_client.update_post_meta(product_id, "_manage_stock", "yes")
+                        woo_client.update_post_meta(product_id, "_stock", str(stock_total))
+                        woo_client.update_post_meta(
+                            product_id,
+                            "_stock_status",
+                            "instock" if stock_total > 0 else "outofstock",
+                        )
+                        if precio_objetivo > 0:
+                            price_text = format_price(precio_objetivo)
+                            woo_client.update_post_meta(product_id, "_price", price_text)
+                            woo_client.update_post_meta(product_id, "_regular_price", price_text)
+                        if weight is not None:
+                            woo_client.update_post_meta(product_id, "_weight", str(weight))
+                        if brand:
+                            woo_client.set_brand(product_id, brand)
+                        if category:
+                            woo_client.set_category(product_id, category)
+                        if should_update_image and image_source:
+                            woo_client.import_image(product_id, image_source)
+                    except WPCLIError as exc:
+                        entry["action"] = "error"
+                        entry["reason"] = format_wp_error(exc)
+                        skipped.append(entry)
+                        metrics["skipped"] += 1
+                        metrics["wp_errors"] += 1
+                        log.write(f"{sku}: error WP create → {exc}\n")
+                        continue
                 created.append(entry)
                 metrics["created"] += 1
                 log.write(
@@ -345,6 +766,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--report", required=True)
     parser.add_argument("--dry-run", type=int, choices=[0, 1], default=1)
     parser.add_argument("--summary", action="append", default=[])
+    parser.add_argument("--writer", choices=["sim", "wp"], default=None)
+    parser.add_argument("--wp-path", default=None)
+    parser.add_argument("--wp-args", default=None)
     return parser.parse_args()
 
 

--- a/python/stage11_postcheck.py
+++ b/python/stage11_postcheck.py
@@ -1,11 +1,117 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import os
 import random
+import shlex
+import subprocess
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
-from pipeline_utils import ensure_parent_dir, update_summary
+from pipeline_utils import ensure_parent_dir, parse_float, parse_int, update_summary
+
+
+class WPCLIError(RuntimeError):
+    """Raised when a WP-CLI command fails."""
+
+
+class WooReader:
+    def __init__(self, wp_path: str, wp_args: str) -> None:
+        self.wp_path = wp_path or "wp"
+        self.wp_args = shlex.split(wp_args) if wp_args else []
+
+    def _build_cmd(self, args: Iterable[str]) -> List[str]:
+        return [self.wp_path, *self.wp_args, *list(args)]
+
+    def run(self, args: Iterable[str], *, check: bool = True) -> subprocess.CompletedProcess:
+        cmd = self._build_cmd(args)
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True)
+        except FileNotFoundError as exc:
+            raise WPCLIError(f"wp_cli_not_found:{exc}") from exc
+        if check and result.returncode != 0:
+            message = result.stderr.strip() or result.stdout.strip() or " ".join(cmd)
+            raise WPCLIError(message)
+        return result
+
+    def find_product_id(self, sku: str) -> Optional[int]:
+        if not sku:
+            return None
+        result = self.run(
+            [
+                "post",
+                "list",
+                "--post_type=product",
+                "--meta_key=_sku",
+                f"--meta_value={sku}",
+                "--fields=ID",
+                "--format=ids",
+            ],
+            check=True,
+        )
+        output = (result.stdout or "").strip()
+        if not output:
+            return None
+        for part in output.split():
+            try:
+                product_id = int(part.strip())
+            except (TypeError, ValueError):
+                continue
+            if product_id > 0:
+                return product_id
+        return None
+
+    def get_post_field(self, product_id: int, field: str) -> str:
+        result = self.run(["post", "get", str(product_id), f"--field={field}"], check=False)
+        if result.returncode != 0:
+            return ""
+        return (result.stdout or "").strip()
+
+    def get_post_meta(self, product_id: int, key: str) -> str:
+        result = self.run(["post", "meta", "get", str(product_id), key], check=False)
+        if result.returncode != 0:
+            return ""
+        return (result.stdout or "").strip()
+
+    def get_terms(self, product_id: int, taxonomy: str) -> List[Dict[str, Any]]:
+        result = self.run(
+            [
+                "term",
+                "list",
+                taxonomy,
+                f"--object_id={product_id}",
+                "--fields=term_id,name,slug",
+                "--format=json",
+            ],
+            check=False,
+        )
+        if result.returncode != 0:
+            return []
+        try:
+            data = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError:
+            return []
+        if isinstance(data, list):
+            return [item for item in data if isinstance(item, Mapping)]
+        return []
+
+
+def format_wp_error(exc: Exception) -> str:
+    message = str(exc).strip().replace("\r", " ").replace("\n", " ")
+    message = " ".join(message.split())
+    return f"wp_error:{message}" if message else "wp_error:unknown"
+
+
+def to_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"1", "true", "yes", "y", "si", "sí"}:
+            return True
+    return False
 
 
 def ensure_summary_paths(run_dir: Path, explicit: Iterable[str]) -> List[Path]:
@@ -53,6 +159,8 @@ def collect_samples(created: List[Mapping[str, Any]], updated: List[Mapping[str,
                 "category": after.get("category"),
                 "image_set": after.get("set_image"),
                 "brand": after.get("brand"),
+                "action": item.get("action"),
+                "reason": item.get("reason"),
             }
         )
     return samples
@@ -85,6 +193,14 @@ def stage11(args: argparse.Namespace) -> None:
     run_id = args.run_id or run_dir.name
     summary_paths = ensure_summary_paths(run_dir, args.summary)
 
+    env_writer = (args.writer or os.environ.get("IMPORT_WRITER") or os.environ.get("WRITER") or "sim").strip().lower()
+    writer = env_writer if env_writer in {"sim", "wp"} else "sim"
+    if writer == "wp" and dry_run and to_bool(os.environ.get("FORCE_WRITE")):
+        dry_run = False
+    wp_path = args.wp_path or os.environ.get("WP_PATH", "wp")
+    wp_args = args.wp_args or os.environ.get("WP_PATH_ARGS", "")
+    real_mode = writer == "wp" and not dry_run
+
     ensure_parent_dir(log_path)
     ensure_parent_dir(postcheck_path)
 
@@ -105,26 +221,159 @@ def stage11(args: argparse.Namespace) -> None:
     samples = collect_samples(created, updated)
 
     diffs: List[Dict[str, Any]] = []
+    wp_error_count = 0
+
+    woo_reader = WooReader(wp_path, wp_args) if real_mode else None
 
     with log_path.open("w", encoding="utf-8") as log:
-        log.write("== Stage 11: post-import check (simulación)==\n")
+        log.write(f"== Stage 11: post-import check (writer={writer})==\n")
         log.write(f"Dry-run={'yes' if dry_run else 'no'}\n")
         log.write(
             f"Conteos → created={counts['created']} updated={counts['updated']} skipped={counts['skipped']}\n"
         )
         if price_zero_items:
             log.write(f"Guardas price_zero: {len(price_zero_items)} casos.\n")
+        if real_mode and woo_reader is not None:
+            log.write("Modo real: consultando WooCommerce vía WP-CLI.\n")
+            for sample in samples:
+                sku = str(sample.get("sku") or "").strip()
+                if not sku:
+                    continue
+                try:
+                    product_id = woo_reader.find_product_id(sku)
+                except WPCLIError as exc:
+                    sample["woo_error"] = format_wp_error(exc)
+                    diffs.append(
+                        {
+                            "sku": sku,
+                            "field": "product_id",
+                            "expected": "exists",
+                            "actual": "wp_error",
+                        }
+                    )
+                    wp_error_count += 1
+                    log.write(f"{sku}: error consultando Woo → {exc}\n")
+                    continue
+                if not product_id:
+                    sample["woo_found"] = False
+                    diffs.append(
+                        {
+                            "sku": sku,
+                            "field": "product_id",
+                            "expected": "exists",
+                            "actual": "missing",
+                        }
+                    )
+                    log.write(f"{sku}: producto no encontrado en Woo.\n")
+                    continue
+
+                sample["woo_found"] = True
+                log.write(f"{sku}: verificación en Woo ID {product_id}.\n")
+
+                actual_name = woo_reader.get_post_field(product_id, "post_title")
+                actual_name = (actual_name or "").strip()
+                actual_price_value = parse_float(
+                    woo_reader.get_post_meta(product_id, "_price"), 0.0
+                )
+                actual_stock_value = parse_int(
+                    woo_reader.get_post_meta(product_id, "_stock"), 0
+                )
+                brand_terms = woo_reader.get_terms(product_id, "product_brand")
+                actual_brand = ""
+                if brand_terms:
+                    actual_brand = str(brand_terms[0].get("name") or "").strip()
+                cat_terms = woo_reader.get_terms(product_id, "product_cat")
+                actual_category = ""
+                if cat_terms:
+                    term = cat_terms[0]
+                    actual_category = str(
+                        term.get("term_id") or term.get("name") or ""
+                    ).strip()
+
+                sample["woo_name"] = actual_name
+                sample["woo_price"] = round(actual_price_value, 2)
+                sample["woo_stock"] = actual_stock_value
+                sample["woo_brand"] = actual_brand
+                sample["woo_category"] = actual_category
+
+                expected_name = str(sample.get("name") or "").strip()
+                expected_price_value = round(parse_float(sample.get("price"), 0.0), 2)
+                expected_stock_value = parse_int(sample.get("stock"), 0)
+                expected_brand = str(sample.get("brand") or "").strip()
+                expected_category = str(sample.get("category") or "").strip()
+
+                if expected_name and actual_name != expected_name:
+                    diffs.append(
+                        {
+                            "sku": sku,
+                            "field": "name",
+                            "expected": expected_name,
+                            "actual": actual_name,
+                        }
+                    )
+
+                guard_price_zero = sample.get("reason") == "price_zero"
+                if guard_price_zero:
+                    sample["price_guard"] = True
+                else:
+                    if expected_price_value != round(actual_price_value, 2):
+                        diffs.append(
+                            {
+                                "sku": sku,
+                                "field": "price",
+                                "expected": expected_price_value,
+                                "actual": round(actual_price_value, 2),
+                            }
+                        )
+
+                if expected_stock_value != actual_stock_value:
+                    diffs.append(
+                        {
+                            "sku": sku,
+                            "field": "stock",
+                            "expected": expected_stock_value,
+                            "actual": actual_stock_value,
+                        }
+                    )
+
+                if expected_brand and actual_brand != expected_brand:
+                    diffs.append(
+                        {
+                            "sku": sku,
+                            "field": "brand",
+                            "expected": expected_brand,
+                            "actual": actual_brand,
+                        }
+                    )
+
+                if expected_category and actual_category != expected_category:
+                    diffs.append(
+                        {
+                            "sku": sku,
+                            "field": "category",
+                            "expected": expected_category,
+                            "actual": actual_category,
+                        }
+                    )
+        else:
+            log.write("Modo simulación (sin consulta a Woo).\n")
+
         if diffs:
             log.write(f"Se detectaron {len(diffs)} diferencias.\n")
         else:
-            log.write("Sin diferencias detectadas (modo simulación).\n")
+            if real_mode:
+                log.write("Sin diferencias detectadas contra Woo.\n")
+            else:
+                log.write("Sin diferencias detectadas (modo simulación).\n")
 
     postcheck_payload = {
         "counts": counts,
         "samples": samples,
         "diffs": diffs,
         "price_zero_guard": price_zero_items,
-        "mode": "simulation" if dry_run else "simulation_no_wp",
+        "mode": "wp" if real_mode else "simulation",
+        "writer": writer,
+        "wp_errors": wp_error_count,
     }
 
     with postcheck_path.open("w", encoding="utf-8") as fh:
@@ -135,13 +384,17 @@ def stage11(args: argparse.Namespace) -> None:
     ensure_parent_dir(readme_dir / "dummy")
     readme_path = readme_dir / "README.md"
     with readme_path.open("w", encoding="utf-8") as readme:
-        readme.write("# Stage 11 - Postcheck (simulación)\n\n")
+        readme.write(f"# Stage 11 - Postcheck (writer={writer})\n\n")
         readme.write(f"- Run ID: {run_id}\n")
         readme.write(f"- Dry-run: {'sí' if dry_run else 'no'}\n")
+        readme.write(f"- Modo: {'Woo real' if real_mode else 'Simulación'}\n")
         readme.write(
             f"- Conteos: created={counts['created']} updated={counts['updated']} skipped={counts['skipped']}\n"
         )
         readme.write(f"- Casos price_zero: {len(price_zero_items)}\n")
+        readme.write(f"- Diferencias detectadas: {len(diffs)}\n")
+        if real_mode:
+            readme.write(f"- WP-CLI errores: {wp_error_count}\n")
 
     metrics = {
         "rows_total": counts["created"] + counts["updated"] + counts["skipped"],
@@ -149,6 +402,10 @@ def stage11(args: argparse.Namespace) -> None:
         "updated": counts["updated"],
         "skipped": counts["skipped"],
         "price_zero": len(price_zero_items),
+        "diffs": len(diffs),
+        "mode": "wp" if real_mode else "simulation",
+        "writer": writer,
+        "wp_errors": wp_error_count,
     }
 
     update_summary(summary_paths, "stage_11", metrics)
@@ -163,6 +420,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--dry-run", type=int, choices=[0, 1], default=1)
     parser.add_argument("--run-id", default="")
     parser.add_argument("--summary", action="append", default=[])
+    parser.add_argument("--writer", choices=["sim", "wp"], default=None)
+    parser.add_argument("--wp-path", default=None)
+    parser.add_argument("--wp-args", default=None)
     return parser.parse_args()
 
 

--- a/tests/run_stage10_11.sh
+++ b/tests/run_stage10_11.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 CSV="tests/data/stage10_media_sample.jsonl"
 RUN_DIR="tests/tmp/run-stage10-11-$(date +%s)"
 DRY_RUN=1
+WRITER="sim"
+WP_PATH="${WP_PATH:-wp}"
+WP_PATH_ARGS="${WP_PATH_ARGS:---path=/home/compustar/htdocs --no-color}"
+WP_ROOT=""
+PLUGIN_DIR=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -17,6 +22,27 @@ while [[ $# -gt 0 ]]; do
       ;;
     --dry-run=*)
       DRY_RUN="${1#*=}"
+      shift
+      ;;
+    --writer=*)
+      WRITER="${1#*=}"
+      shift
+      ;;
+    --wp-path=*)
+      WP_PATH="${1#*=}"
+      shift
+      ;;
+    --wp-args=*)
+      WP_PATH_ARGS="${1#*=}"
+      shift
+      ;;
+    --wp-root=*)
+      WP_ROOT="${1#*=}"
+      WP_PATH_ARGS="--path=${WP_ROOT} --no-color"
+      shift
+      ;;
+    --plugin-dir=*)
+      PLUGIN_DIR="${1#*=}"
       shift
       ;;
     *)
@@ -41,12 +67,22 @@ if ! command -v "$PYTHON" >/dev/null 2>&1; then
   PYTHON=python
 fi
 
+export WP_PATH
+export WP_PATH_ARGS
+
+if [[ "$WRITER" == "wp" && "$DRY_RUN" == "0" ]]; then
+  echo "== IMPORT MODE: writer=wp (real) =="
+fi
+
 $PYTHON python/stage10_import.py \
   --run-dir "$RUN_DIR" \
   --input "$RUN_DIR/media.jsonl" \
   --log "$RUN_DIR/logs/stage-10.log" \
   --report "$RUN_DIR/final/import-report.json" \
-  --dry-run "$DRY_RUN"
+  --dry-run "$DRY_RUN" \
+  --writer "$WRITER" \
+  --wp-path "$WP_PATH" \
+  --wp-args "$WP_PATH_ARGS"
 
 $PYTHON python/stage11_postcheck.py \
   --run-dir "$RUN_DIR" \
@@ -54,7 +90,10 @@ $PYTHON python/stage11_postcheck.py \
   --postcheck "$RUN_DIR/final/postcheck.json" \
   --log "$RUN_DIR/logs/stage-11.log" \
   --dry-run "$DRY_RUN" \
-  --run-id "$(basename "$RUN_DIR")"
+  --run-id "$(basename "$RUN_DIR")" \
+  --writer "$WRITER" \
+  --wp-path "$WP_PATH" \
+  --wp-args "$WP_PATH_ARGS"
 
 for path in "$RUN_DIR/final/import-report.json" "$RUN_DIR/final/postcheck.json" \
             "$RUN_DIR/logs/stage-10.log" "$RUN_DIR/logs/stage-11.log"; do


### PR DESCRIPTION
## Summary
- add a WooCommerce client to stage 10 that can create and update products via WP-CLI when writer=wp and dry-run=0
- extend stage 11 to query WooCommerce for post-check verification and include mode/metrics in reports and README
- allow the stage10/11 test harness to pass writer and WP-CLI settings through to the Python stages with clearer logging

## Testing
- bash tests/run_stage10_11.sh

------
https://chatgpt.com/codex/tasks/task_b_68e84cacb1a483208dd62afaa3b342a1