### PR TITLE
Implement WooCommerce import and postcheck stages

### DIFF
--- a/python/stage10_import.py
+++ b/python/stage10_import.py
@@ -2,10 +2,12 @@
 import argparse
 import json
 import os
+import random
 import shlex
 import subprocess
+import time
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, MutableMapping, Optional, Sequence, Tuple
 
 from pipeline_utils import (
     ensure_parent_dir,
@@ -16,11 +18,116 @@ from pipeline_utils import (
 )
 
 
-DEFAULT_SUMMARY_KEYS = ("stage_10",)
-
-
 class WPCLIError(RuntimeError):
     """Raised when a WP-CLI command fails."""
+
+
+def slugify(text: str) -> str:
+    normalized = str(text or "").strip().lower()
+    if not normalized:
+        return "general"
+    cleaned: List[str] = []
+    for char in normalized:
+        if char.isalnum():
+            cleaned.append(char)
+        elif char in {" ", "-", "_", ".", "/"}:
+            cleaned.append("-" if char in {" ", "/"} else char)
+    slug = "".join(cleaned)
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    slug = slug.strip("-_.")
+    return slug or "general"
+
+
+def normalize_category_path(raw: Any) -> List[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, (list, tuple)):
+        parts: List[str] = []
+        for item in raw:
+            for segment in normalize_category_path(item):
+                if segment:
+                    parts.append(segment)
+        return parts
+    text = str(raw).strip()
+    if not text:
+        return []
+    if ">" in text:
+        parts = [segment.strip() for segment in text.split(">")]
+    elif "|" in text:
+        parts = [segment.strip() for segment in text.split("|")]
+    elif "/" in text:
+        parts = [segment.strip() for segment in text.split("/")]
+    else:
+        return [text]
+    return [part for part in parts if part]
+
+
+def build_name(record: Mapping[str, Any]) -> str:
+    explicit = str(record.get("Nombre", "")).strip()
+    if explicit:
+        return explicit
+    parts: List[str] = []
+    for key in ("Marca", "Modelo", "Titulo", "Title"):
+        value = str(record.get(key, "")).strip()
+        if value:
+            parts.append(value)
+    fallback = str(record.get("sku", "")).strip()
+    if parts:
+        return " ".join(parts)
+    return fallback or "Producto"
+
+
+def extract_description(record: Mapping[str, Any]) -> str:
+    for key in ("Descripcion", "descripcion", "description", "Descripcion_HTML", "descripcion_html"):
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def extract_image_source(record: Mapping[str, Any]) -> str:
+    for key in (
+        "Imagen_Principal",
+        "image",
+        "image_url",
+        "image_path",
+        "image_local_path",
+        "imagen",
+    ):
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def compute_stock_info(record: Mapping[str, Any]) -> Dict[str, Any]:
+    total = parse_int(record.get("stock_total_mayoristas"), -1)
+    syscom = parse_int(record.get("stock_for_import"), 0)
+    mayoristas: Dict[str, int] = {}
+    if isinstance(record.get("stocks_por_mayorista"), Mapping):
+        for key, value in record["stocks_por_mayorista"].items():
+            qty = max(0, parse_int(value))
+            if qty:
+                mayoristas[str(key)] = qty
+    for key, value in record.items():
+        if not isinstance(key, str):
+            continue
+        if not key.startswith("stock_"):
+            continue
+        if key in {"stock_for_import", "stock_total_mayoristas"}:
+            continue
+        qty = max(0, parse_int(value))
+        if qty:
+            mayoristas[key] = qty
+    if total < 0:
+        total = syscom + sum(mayoristas.values())
+    total = max(0, total)
+    return {
+        "stock_total_mayoristas": total,
+        "stock_syscom": max(0, syscom),
+        "stock_mayoristas": mayoristas,
+    }
 
 
 class WooClient:
@@ -30,32 +137,59 @@ class WooClient:
         wp_args: str,
         log,
         write_enabled: bool,
+        retries: int = 2,
     ) -> None:
         self.wp_path = wp_path or "wp"
         self.wp_args = shlex.split(wp_args) if wp_args else []
         self.log = log
         self.write_enabled = write_enabled
+        self.retries = max(0, retries)
+        self._term_cache: Dict[Tuple[str, str, int], Dict[str, Any]] = {}
+        self._term_by_name_cache: Dict[Tuple[str, str], Dict[str, Any]] = {}
 
     def _build_cmd(self, args: Iterable[str]) -> List[str]:
         return [self.wp_path, *self.wp_args, *list(args)]
 
-    def _format_cmd(self, cmd: Iterable[str]) -> str:
+    def _format_cmd(self, cmd: Sequence[str]) -> str:
         return " ".join(shlex.quote(part) for part in cmd)
 
-    def run(self, args: Iterable[str], *, write: bool = False, check: bool = True) -> subprocess.CompletedProcess:
+    def run(
+        self,
+        args: Iterable[str],
+        *,
+        write: bool = False,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess:
         cmd = self._build_cmd(args)
+        cmd_fmt = self._format_cmd(cmd)
         if write and not self.write_enabled:
-            if self.log is not None:
-                self.log.write(f"[dry-run] {self._format_cmd(cmd)}\n")
+            if self.log:
+                self.log.write(f"[dry-run] {cmd_fmt}\n")
             return subprocess.CompletedProcess(cmd, 0, "", "")
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True)
-        except FileNotFoundError as exc:
-            raise WPCLIError(f"wp_cli_not_found:{exc}") from exc
-        if check and result.returncode != 0:
-            message = result.stderr.strip() or result.stdout.strip() or self._format_cmd(cmd)
+        attempts = 0
+        while True:
+            attempts += 1
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True)
+            except FileNotFoundError as exc:
+                raise WPCLIError(f"wp_cli_not_found:{exc}") from exc
+            if result.returncode == 0 or not check:
+                if self.log and result.returncode != 0:
+                    self.log.write(
+                        f"cmd rc={result.returncode} (ignored) → {cmd_fmt}\nstderr: {result.stderr.strip()}\n"
+                    )
+                return result
+            message = result.stderr.strip() or result.stdout.strip() or cmd_fmt
+            if attempts <= self.retries:
+                if self.log:
+                    self.log.write(
+                        f"retry ({attempts}/{self.retries}) rc={result.returncode} → {cmd_fmt}\n"
+                    )
+                    if result.stderr:
+                        self.log.write(f"stderr: {result.stderr}\n")
+                time.sleep(0.5)
+                continue
             raise WPCLIError(message)
-        return result
 
     def find_product_id(self, sku: str) -> Optional[int]:
         if not sku:
@@ -77,40 +211,31 @@ class WooClient:
             return None
         for part in output.split():
             try:
-                product_id = int(part.strip())
+                value = int(part.strip())
             except (TypeError, ValueError):
                 continue
-            if product_id > 0:
-                return product_id
+            if value > 0:
+                return value
         return None
 
     def get_post_field(self, product_id: int, field: str) -> str:
-        result = self.run(
-            ["post", "get", str(product_id), f"--field={field}"],
-            write=False,
-            check=False,
-        )
+        result = self.run(["post", "get", str(product_id), f"--field={field}"], write=False, check=False)
         if result.returncode != 0:
             return ""
         return (result.stdout or "").strip()
 
     def get_post_meta(self, product_id: int, key: str) -> str:
-        result = self.run(
-            ["post", "meta", "get", str(product_id), key],
-            write=False,
-            check=False,
-        )
+        result = self.run(["post", "meta", "get", str(product_id), key], write=False, check=False)
         if result.returncode != 0:
             return ""
         return (result.stdout or "").strip()
 
     def update_post_meta(self, product_id: int, key: str, value: str) -> None:
-        self.run(
-            ["post", "meta", "update", str(product_id), key, value],
-            write=True,
-        )
+        self.run(["post", "meta", "update", str(product_id), key, value], write=True)
 
     def post_update(self, product_id: int, **fields: str) -> None:
+        if not fields:
+            return
         args = ["post", "update", str(product_id)]
         for key, value in fields.items():
             args.append(f"--{key}={value}")
@@ -125,62 +250,117 @@ class WooClient:
         try:
             product_id = int(output)
         except (TypeError, ValueError):
-            raise WPCLIError(f"post create → respuesta inesperada: {output}")
+            raise WPCLIError(f"post_create_invalid_output:{output}")
         if product_id <= 0:
-            raise WPCLIError(f"post create → ID inválido: {output}")
+            raise WPCLIError(f"post_create_invalid_id:{output}")
         return product_id
 
-    def product_has_image(self, product_id: int) -> bool:
-        thumbnail_id = self.get_post_meta(product_id, "_thumbnail_id")
-        return bool(thumbnail_id)
-
-    def product_has_description(self, product_id: int) -> bool:
-        content = self.get_post_field(product_id, "post_content")
-        return bool(content)
-
-    def ensure_brand(self, brand: str) -> None:
-        if not brand:
-            return
-        slug = slugify(brand)
+    def _list_terms(self, taxonomy: str, slug: str) -> Optional[Dict[str, Any]]:
+        cache_key = (taxonomy, slug)
+        if cache_key in self._term_by_name_cache:
+            return self._term_by_name_cache[cache_key]
         result = self.run(
             [
                 "term",
-                "create",
-                "product_brand",
-                brand,
+                "list",
+                taxonomy,
                 f"--slug={slug}",
+                "--fields=term_id,slug,name,parent",
+                "--format=json",
             ],
-            write=True,
+            write=False,
             check=False,
         )
-        if result.returncode not in (0,):
-            message = (result.stderr or "").lower()
-            if "term already exists" not in message:
-                raise WPCLIError(result.stderr.strip() or result.stdout.strip() or "term create error")
+        if result.returncode != 0:
+            return None
+        try:
+            data = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError:
+            data = []
+        if isinstance(data, list) and data:
+            term = data[0]
+            if isinstance(term, Mapping):
+                self._term_by_name_cache[cache_key] = dict(term)
+                return dict(term)
+        return None
 
-    def set_brand(self, product_id: int, brand: str) -> None:
+    def ensure_term(self, taxonomy: str, name: str, parent: int = 0) -> int:
+        slug = slugify(name)
+        cache_key = (taxonomy, slug, parent or 0)
+        cached = self._term_cache.get(cache_key)
+        if cached:
+            term_id = parse_int(cached.get("term_id"), 0)
+            if term_id > 0:
+                return term_id
+        existing = self._list_terms(taxonomy, slug)
+        if existing:
+            term_id = parse_int(existing.get("term_id"), 0)
+            if term_id > 0:
+                self._term_cache[cache_key] = dict(existing)
+                return term_id
+        args = ["term", "create", taxonomy, name, f"--slug={slug}", "--porcelain"]
+        if parent:
+            args.append(f"--parent={parent}")
+        result = self.run(args, write=True, check=False)
+        if result.returncode == 0:
+            output = (result.stdout or "").strip()
+            try:
+                term_id = int(output)
+            except (TypeError, ValueError):
+                term_id = 0
+            if term_id <= 0:
+                raise WPCLIError(f"term_create_invalid_output:{taxonomy}:{name}:{output}")
+            payload = {"term_id": term_id, "slug": slug, "name": name, "parent": parent}
+            self._term_cache[cache_key] = payload
+            self._term_by_name_cache[(taxonomy, slug)] = payload
+            return term_id
+        message = (result.stderr or "").lower()
+        if "already exists" in message or "ya existe" in message or "existe" in message:
+            existing = self._list_terms(taxonomy, slug)
+            if existing:
+                term_id = parse_int(existing.get("term_id"), 0)
+                if term_id > 0:
+                    self._term_cache[cache_key] = dict(existing)
+                    return term_id
+        raise WPCLIError(result.stderr.strip() or result.stdout.strip() or "term_create_error")
+
+    def ensure_category(self, raw_category: Any) -> Optional[int]:
+        parts = normalize_category_path(raw_category)
+        if not parts:
+            if isinstance(raw_category, (int, float)):
+                return parse_int(raw_category, 0)
+            text = str(raw_category or "").strip()
+            if text.isdigit():
+                return parse_int(text, 0)
+            if text:
+                return self.ensure_term("product_cat", text, 0)
+            return None
+        parent = 0
+        term_id = None
+        for part in parts:
+            term_id = self.ensure_term("product_cat", part, parent)
+            parent = term_id
+        return term_id
+
+    def ensure_brand(self, brand: str) -> Optional[int]:
         if not brand:
+            return None
+        return self.ensure_term("product_brand", brand, 0)
+
+    def set_terms(self, taxonomy: str, product_id: int, term_id: int) -> None:
+        if term_id <= 0:
             return
-        self.ensure_brand(brand)
         self.run(
             [
                 "term",
                 "set",
-                "product_brand",
+                taxonomy,
                 str(product_id),
-                brand,
-                "--by=name",
+                str(term_id),
+                "--by=id",
             ],
             write=True,
         )
-
-    def set_category(self, product_id: int, category: str) -> None:
-        if not category:
-            return
-        args = ["term", "set", "product_cat", str(product_id), str(category)]
-        if str(category).isdigit():
-            args.append("--by=id")
-        self.run(args, write=True)
 
     def import_image(self, product_id: int, source: str) -> None:
         if not source:
@@ -190,12 +370,21 @@ class WooClient:
                 "media",
                 "import",
                 source,
-                "--featured_image",
                 f"--post_id={product_id}",
+                "--featured_image",
                 "--porcelain",
             ],
             write=True,
         )
+
+    def has_thumbnail(self, product_id: int) -> bool:
+        return bool(self.get_post_meta(product_id, "_thumbnail_id"))
+
+    def has_description(self, product_id: int) -> bool:
+        return bool(self.get_post_field(product_id, "post_content"))
+
+    def db_query(self, sql: str, write: bool = False) -> subprocess.CompletedProcess:
+        return self.run(["db", "query", sql, "--skip-column-names"], write=write)
 
     def get_terms(self, product_id: int, taxonomy: str) -> List[Dict[str, Any]]:
         result = self.run(
@@ -216,550 +405,215 @@ class WooClient:
             data = json.loads(result.stdout or "[]")
         except json.JSONDecodeError:
             return []
+        terms: List[Dict[str, Any]] = []
         if isinstance(data, list):
-            return [item for item in data if isinstance(item, Mapping)]
-        return []
+            for item in data:
+                if isinstance(item, Mapping):
+                    terms.append(dict(item))
+        return terms
 
 
-def slugify(text: str) -> str:
-    normalized = str(text).strip().lower()
-    cleaned = []
-    for char in normalized:
-        if char.isalnum():
-            cleaned.append(char)
-        elif char in {" ", "-", "_", "."}:
-            cleaned.append("-" if char == " " else char)
-    slug = "".join(cleaned)
-    while "--" in slug:
-        slug = slug.replace("--", "-")
-    slug = slug.strip("-_.")
-    return slug or "marca"
+def safe_sql_value(value: Any) -> str:
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if isinstance(value, float):
+            return str(round(value, 6))
+        return str(value)
+    text = str(value)
+    escaped = text.replace("'", "''")
+    return f"'{escaped}'"
 
 
-def extract_description(record: Mapping[str, Any]) -> str:
-    keys = (
-        "descripcion_html",
-        "description_html",
-        "descripcion",
-        "Descripcion",
-        "description",
-    )
-    for key in keys:
-        value = record.get(key)
-        if isinstance(value, str):
-            text = value.strip()
-            if text:
-                return text
-    return ""
+class MirrorManager:
+    TABLES = {
+        "wp_compu_products": {
+            "required": {"sku"},
+            "columns": {
+                "sku",
+                "nombre",
+                "marca",
+                "cat_term_id",
+                "cat_slug",
+                "peso_kg",
+                "image_set",
+                "run_id",
+                "updated_at",
+            },
+        },
+        "wp_compu_prices": {
+            "required": {"sku"},
+            "columns": {
+                "sku",
+                "net",
+                "gross_16",
+                "gross_8",
+                "price_16_final",
+                "tipo_de_cambio",
+                "margen_tipo",
+                "margen_valor",
+                "run_id",
+            },
+        },
+        "wp_compu_inventory": {
+            "required": {"sku"},
+            "columns": {
+                "sku",
+                "stock_total_mayoristas",
+                "Almacen_15",
+                "Almacen_15_Tijuana",
+                "run_id",
+            },
+        },
+    }
 
+    def __init__(self, client: WooClient, log, run_id: str) -> None:
+        self.client = client
+        self.log = log
+        self.run_id = run_id
+        self._detected = False
+        self._available_columns: Dict[str, set] = {}
 
-def extract_image_source(record: Mapping[str, Any]) -> str:
-    keys = (
-        "image_url",
-        "Imagen_Principal",
-        "image",
-        "imagen",
-        "image_path",
-        "image_local_path",
-    )
-    for key in keys:
-        value = record.get(key)
-        if isinstance(value, str):
-            text = value.strip()
-            if text:
-                return text
-    return ""
+    def detect(self) -> None:
+        if self._detected:
+            return
+        self._detected = True
+        try:
+            result = self.client.db_query("SHOW TABLES LIKE 'wp_compu_%';", write=False)
+        except WPCLIError as exc:
+            if self.log:
+                self.log.write(f"mirror detect error: {exc}\n")
+            return
+        tables = set()
+        output = (result.stdout or "").strip().splitlines()
+        for line in output:
+            table = line.strip()
+            if table:
+                tables.add(table)
+        for table, spec in self.TABLES.items():
+            if table not in tables:
+                continue
+            try:
+                cols_result = self.client.db_query(f"SHOW COLUMNS FROM {table};", write=False)
+            except WPCLIError as exc:
+                if self.log:
+                    self.log.write(f"mirror columns error {table}: {exc}\n")
+                continue
+            available = set()
+            for line in (cols_result.stdout or "").splitlines():
+                parts = line.strip().split("\t")
+                if parts:
+                    available.add(parts[0])
+            if spec["required"].issubset(available):
+                self._available_columns[table] = available
+            else:
+                if self.log:
+                    self.log.write(
+                        f"mirror table {table} missing required columns {spec['required'] - available}\n"
+                    )
 
+    def upsert(self, table: str, payload: Mapping[str, Any]) -> bool:
+        self.detect()
+        available = self._available_columns.get(table)
+        if not available:
+            return False
+        columns = []
+        values = []
+        updates = []
+        for key, value in payload.items():
+            if key not in available:
+                continue
+            columns.append(key)
+            values.append(safe_sql_value(value))
+            updates.append(f"{key}=VALUES({key})")
+        if not columns:
+            return False
+        if "updated_at" in available and "updated_at" not in payload:
+            columns.append("updated_at")
+            values.append("NOW()")
+            updates.append("updated_at=NOW()")
+        sql = (
+            f"INSERT INTO {table} ({', '.join(columns)}) VALUES ({', '.join(values)}) "
+            f"ON DUPLICATE KEY UPDATE {', '.join(updates)};"
+        )
+        self.client.db_query(sql, write=True)
+        return True
 
-def format_wp_error(exc: Exception) -> str:
-    message = str(exc).strip().replace("\r", " ").replace("\n", " ")
-    message = " ".join(message.split())
-    return f"wp_error:{message}" if message else "wp_error:unknown"
+    def apply(self, sku: str, record: Mapping[str, Any], product_payload: Mapping[str, Any]) -> str:
+        updated_any = False
+        partial = False
+        products_payload = {
+            "sku": sku,
+            "nombre": product_payload.get("name"),
+            "marca": product_payload.get("brand"),
+            "cat_term_id": product_payload.get("category_id"),
+            "cat_slug": product_payload.get("category_slug"),
+            "peso_kg": product_payload.get("weight"),
+            "image_set": 1 if product_payload.get("image_set") else 0,
+            "run_id": self.run_id,
+        }
+        prices_payload = {
+            "sku": sku,
+            "net": record.get("net"),
+            "gross_16": record.get("gross_16"),
+            "gross_8": record.get("gross_8"),
+            "price_16_final": record.get("price_16_final"),
+            "tipo_de_cambio": record.get("Tipo_de_Cambio"),
+            "margen_tipo": record.get("margin_type"),
+            "margen_valor": record.get("margin_value"),
+            "run_id": self.run_id,
+        }
+        inventory_payload = {
+            "sku": sku,
+            "stock_total_mayoristas": product_payload.get("stock"),
+            "Almacen_15": record.get("Almacen_15"),
+            "Almacen_15_Tijuana": record.get("Almacen_15_Tijuana"),
+            "run_id": self.run_id,
+        }
+        try:
+            if self.upsert("wp_compu_products", products_payload):
+                updated_any = True
+            else:
+                partial = True
+        except WPCLIError as exc:
+            partial = True
+            if self.log:
+                self.log.write(f"mirror products error: {exc}\n")
+        try:
+            if self.upsert("wp_compu_prices", prices_payload):
+                updated_any = True
+            else:
+                partial = True
+        except WPCLIError as exc:
+            partial = True
+            if self.log:
+                self.log.write(f"mirror prices error: {exc}\n")
+        try:
+            if self.upsert("wp_compu_inventory", inventory_payload):
+                updated_any = True
+            else:
+                partial = True
+        except WPCLIError as exc:
+            partial = True
+            if self.log:
+                self.log.write(f"mirror inventory error: {exc}\n")
+        if updated_any and not partial:
+            return "written"
+        if updated_any and partial:
+            return "partial"
+        if partial:
+            return "partial"
+        return "skipped"
 
 
 def format_price(value: float) -> str:
     return f"{float(value):.2f}"
 
 
-def to_bool(value: Any) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return bool(value)
-    if isinstance(value, str):
-        text = value.strip().lower()
-        if text in {"1", "true", "yes", "y", "si", "sí"}:
-            return True
-    return False
-
-
-def build_name(record: Mapping[str, Any]) -> str:
-    name = str(record.get("Nombre", "")).strip()
-    if name:
-        return name
-    parts: List[str] = []
-    for key in ("Marca", "Modelo", "Titulo"):
-        value = str(record.get(key, "")).strip()
-        if value:
-            parts.append(value)
-    return " ".join(parts)
-
-
-def detect_existing(record: Mapping[str, Any]) -> Tuple[bool, Optional[int]]:
-    possible_ids = (
-        "woo_product_id",
-        "product_id",
-        "id_producto_woo",
-        "woo_id",
-        "post_id",
-    )
-    for key in possible_ids:
-        product_id = parse_int(record.get(key))
-        if product_id > 0:
-            return True, product_id
-    possible_flags = (
-        "woo_exists",
-        "exists_in_woo",
-        "exists",
-    )
-    for key in possible_flags:
-        if to_bool(record.get(key)):
-            return True, None
-    return False, None
-
-
-def has_description(record: Mapping[str, Any]) -> bool:
-    possible_flags = (
-        "woo_has_description",
-        "has_description",
-    )
-    for key in possible_flags:
-        if key in record and to_bool(record.get(key)):
-            return True
-    possible_values = (
-        "woo_description",
-        "description",
-        "post_content",
-    )
-    for key in possible_values:
-        value = record.get(key)
-        if isinstance(value, str) and value.strip():
-            return True
-    return False
-
-
-def has_image(record: Mapping[str, Any]) -> bool:
-    possible_flags = (
-        "woo_has_image",
-        "has_image",
-        "image_set",
-    )
-    for key in possible_flags:
-        if key in record and to_bool(record.get(key)):
-            return True
-    possible_values = (
-        "woo_image",
-        "image",
-        "Imagen_Principal",
-    )
-    for key in possible_values:
-        value = record.get(key)
-        if isinstance(value, str) and value.strip():
-            return True
-    return False
-
-
-def _sum_non_negative(values: Iterable[Any]) -> int:
-    total = 0
-    for value in values:
-        qty = parse_int(value)
-        if qty > 0:
-            total += qty
-    return total
-
-
-def compute_stock_total(record: Mapping[str, Any]) -> Dict[str, Any]:
-    stock_syscom = max(0, parse_int(record.get("stock_for_import")))
-    other_total = 0
-    mayorista_details: Dict[str, int] = {}
-
-    stocks_mayorista = record.get("stocks_por_mayorista")
-    if isinstance(stocks_mayorista, Mapping):
-        for key, value in stocks_mayorista.items():
-            qty = max(0, parse_int(value))
-            if qty > 0:
-                mayorista_details[str(key)] = qty
-                other_total += qty
-    elif isinstance(stocks_mayorista, list):
-        subtotal = _sum_non_negative(stocks_mayorista)
-        other_total += subtotal
-        if subtotal > 0:
-            mayorista_details["list_total"] = subtotal
-    else:
-        for key, value in record.items():
-            if not isinstance(key, str):
-                continue
-            if not key.startswith("stock_"):
-                continue
-            if key in {"stock_for_import", "stock_total"}:
-                continue
-            qty = max(0, parse_int(value))
-            if qty <= 0:
-                continue
-            mayorista_details[key] = qty
-            other_total += qty
-
-    stock_total = max(0, stock_syscom + other_total)
-    return {
-        "stock_syscom": stock_syscom,
-        "stock_mayoristas": mayorista_details,
-        "stock_total_mayoristas": stock_total,
-    }
-
-
-def target_weight(record: Mapping[str, Any]) -> Optional[float]:
-    weight = parse_float(record.get("Peso_Kg"), -1.0)
-    if weight < 0:
-        return None
-    return round(weight, 3)
-
-
-def ensure_summary_paths(run_dir: Path, explicit: Iterable[str]) -> List[Path]:
-    summary_paths = [Path(p) for p in explicit] if explicit else []
-    if not summary_paths:
-        summary_paths = [run_dir / "summary.json", run_dir / "final" / "summary.json"]
-    return summary_paths
-
-
-def stage10(args: argparse.Namespace) -> None:
-    run_dir = Path(args.run_dir)
-    input_path = Path(args.input)
-    log_path = Path(args.log)
-    report_path = Path(args.report)
-    dry_run = bool(args.dry_run)
-    summary_paths = ensure_summary_paths(run_dir, args.summary)
-
-    env_writer = (args.writer or os.environ.get("IMPORT_WRITER") or os.environ.get("WRITER") or "sim").strip().lower()
-    writer = env_writer if env_writer in {"sim", "wp"} else "sim"
-    if writer == "wp" and dry_run and to_bool(os.environ.get("FORCE_WRITE")):
-        dry_run = False
-    wp_path = args.wp_path or os.environ.get("WP_PATH", "wp")
-    wp_args = args.wp_args or os.environ.get("WP_PATH_ARGS", "")
-    write_enabled = writer == "wp" and not dry_run
-    mode = "wp" if write_enabled else "simulation"
-
-    ensure_parent_dir(log_path)
-    ensure_parent_dir(report_path)
-
-    created: List[Dict[str, Any]] = []
-    updated: List[Dict[str, Any]] = []
-    skipped: List[Dict[str, Any]] = []
-
-    metrics: Dict[str, Any] = {
-        "rows_total": 0,
-        "created": 0,
-        "updated": 0,
-        "skipped": 0,
-        "price_zero": 0,
-        "wp_errors": 0,
-        "mode": mode,
-        "writer": writer,
-    }
-
-    if not input_path.exists():
-        raise FileNotFoundError(f"No existe input: {input_path}")
-
-    records = list(read_jsonl(input_path))
-    metrics["rows_total"] = len(records)
-
-    with log_path.open("w", encoding="utf-8") as log:
-        log.write(f"== Stage 10: import (writer={writer})==\n")
-        log.write(f"Dry-run={'yes' if dry_run else 'no'}\n")
-
-        woo_client = (
-            WooClient(wp_path, wp_args, log, write_enabled)
-            if writer == "wp"
-            else None
-        )
-
-        for record in records:
-            sku = str(record.get("sku"))
-            if not sku:
-                log.write("Registro sin SKU, se omite.\n")
-                skipped.append(
-                    {
-                        "sku": sku or "",
-                        "action": "skip",
-                        "reason": "missing_sku",
-                        "stock_total_mayoristas": 0,
-                        "precio_objetivo": 0,
-                    }
-                )
-                metrics["skipped"] += 1
-                continue
-
-            name = build_name(record)
-            brand = str(record.get("Marca", "")).strip()
-            category = str(record.get("ID_Menu_Nvl_3", "")).strip()
-
-            stock_info = compute_stock_total(record)
-            stock_total = stock_info["stock_total_mayoristas"]
-
-            precio_objetivo = parse_float(record.get("price_16_final"), 0.0)
-            if not isinstance(precio_objetivo, (int, float)):
-                precio_objetivo = 0.0
-
-            description_text = extract_description(record)
-            image_source = extract_image_source(record)
-            weight = target_weight(record)
-
-            after_payload: Dict[str, Any] = {
-                "name": name,
-                "brand": brand,
-                "category": category,
-                "stock": stock_total,
-                "price": round(precio_objetivo, 2) if isinstance(precio_objetivo, (int, float)) else 0.0,
-                "update_price": False,
-                "set_description": False,
-                "set_image": False,
-                "weight": weight,
-                "stock_breakdown": {
-                    "syscom": stock_info["stock_syscom"],
-                    "mayoristas": stock_info["stock_mayoristas"],
-                },
-            }
-
-            if weight is None:
-                after_payload.pop("weight")
-
-            entry: Dict[str, Any] = {
-                "sku": sku,
-                "stock_total_mayoristas": stock_total,
-                "precio_objetivo": round(precio_objetivo, 2) if isinstance(precio_objetivo, (int, float)) else 0.0,
-                "before": None,
-                "after": after_payload,
-            }
-
-            before: Dict[str, Any] = {}
-            existing = False
-            product_id: Optional[int] = None
-            current_price = 0.0
-            current_stock = 0
-
-            if writer == "wp" and woo_client is not None:
-                try:
-                    product_id = woo_client.find_product_id(sku)
-                except WPCLIError as exc:
-                    entry["action"] = "skip"
-                    entry["reason"] = format_wp_error(exc)
-                    skipped.append(entry)
-                    metrics["skipped"] += 1
-                    metrics["wp_errors"] += 1
-                    log.write(f"{sku}: error consultando Woo → {exc}\n")
-                    continue
-                existing = product_id is not None
-                if existing and product_id:
-                    before["product_id"] = product_id
-                    existing_name = woo_client.get_post_field(product_id, "post_title")
-                    if existing_name:
-                        before["name"] = existing_name
-                    current_price = parse_float(woo_client.get_post_meta(product_id, "_regular_price"), 0.0)
-                    if current_price > 0:
-                        before["price"] = current_price
-                    current_stock = parse_int(woo_client.get_post_meta(product_id, "_stock"), 0)
-                    before["stock"] = current_stock
-                    brand_terms = woo_client.get_terms(product_id, "product_brand")
-                    if brand_terms:
-                        before_brand = brand_terms[0].get("name")
-                        if before_brand:
-                            before["brand"] = before_brand
-                    cat_terms = woo_client.get_terms(product_id, "product_cat")
-                    if cat_terms:
-                        before_cat = cat_terms[0].get("term_id") or cat_terms[0].get("name")
-                        if before_cat:
-                            before["category"] = before_cat
-                    has_desc = woo_client.product_has_description(product_id)
-                    has_img = woo_client.product_has_image(product_id)
-                else:
-                    has_desc = False
-                    has_img = False
-            else:
-                existing, product_id = detect_existing(record)
-                current_price = parse_float(record.get("woo_regular_price"), 0.0)
-                current_stock = parse_int(record.get("woo_stock"), 0)
-                if existing:
-                    if product_id:
-                        before["product_id"] = product_id
-                    if current_price:
-                        before["price"] = current_price
-                    before["stock"] = current_stock
-                    if record.get("woo_name"):
-                        before["name"] = record.get("woo_name")
-                    if record.get("woo_category"):
-                        before["category"] = record.get("woo_category")
-                    if record.get("woo_brand"):
-                        before["brand"] = record.get("woo_brand")
-                has_desc = has_description(record)
-                has_img = has_image(record)
-
-            if before:
-                entry["before"] = before
-
-            if writer == "wp":
-                should_update_description = bool(description_text) and not has_desc
-                should_update_image = bool(image_source) and not has_img
-            else:
-                should_update_description = not has_desc
-                should_update_image = not has_img
-
-            after_payload["set_description"] = should_update_description
-            after_payload["set_image"] = should_update_image
-
-            if precio_objetivo <= 0:
-                metrics["price_zero"] += 1
-                entry["reason"] = "price_zero"
-                if existing and product_id:
-                    entry["action"] = "update_stock_zero_due_to_price_zero"
-                    after_payload["stock"] = 0
-                    if writer == "wp" and woo_client is not None:
-                        try:
-                            woo_client.update_post_meta(product_id, "_manage_stock", "yes")
-                            woo_client.update_post_meta(product_id, "_stock", "0")
-                            woo_client.update_post_meta(product_id, "_stock_status", "outofstock")
-                        except WPCLIError as exc:
-                            entry["action"] = "error"
-                            entry["reason"] = format_wp_error(exc)
-                            skipped.append(entry)
-                            metrics["skipped"] += 1
-                            metrics["wp_errors"] += 1
-                            log.write(f"{sku}: error WP price_zero → {exc}\n")
-                            continue
-                    updated.append(entry)
-                    metrics["updated"] += 1
-                    log.write(
-                        f"{sku}: price_zero guard → stock=0, sin actualización de precio.\n"
-                    )
-                else:
-                    entry["action"] = "skip_create"
-                    skipped.append(entry)
-                    metrics["skipped"] += 1
-                    log.write(f"{sku}: price_zero guard → no se crea.\n")
-                continue
-
-            if stock_total <= 0:
-                entry["action"] = "skip_create"
-                entry["reason"] = "stock_zero"
-                skipped.append(entry)
-                metrics["skipped"] += 1
-                log.write(f"{sku}: stock total 0 → no se crea/actualiza.\n")
-                continue
-
-            if existing and product_id:
-                entry["action"] = "update"
-                after_payload["update_price"] = bool(
-                    precio_objetivo > 0 and (
-                        current_price <= 0 or round(precio_objetivo, 2) != round(current_price, 2)
-                    )
-                )
-                if writer == "wp" and woo_client is not None:
-                    try:
-                        woo_client.update_post_meta(product_id, "_sku", sku)
-                        woo_client.update_post_meta(product_id, "_manage_stock", "yes")
-                        woo_client.update_post_meta(product_id, "_stock", str(stock_total))
-                        woo_client.update_post_meta(
-                            product_id,
-                            "_stock_status",
-                            "instock" if stock_total > 0 else "outofstock",
-                        )
-                        if precio_objetivo > 0:
-                            price_text = format_price(precio_objetivo)
-                            woo_client.update_post_meta(product_id, "_price", price_text)
-                            woo_client.update_post_meta(product_id, "_regular_price", price_text)
-                        if weight is not None:
-                            woo_client.update_post_meta(product_id, "_weight", str(weight))
-                        update_fields: Dict[str, str] = {}
-                        if name and before.get("name") != name:
-                            update_fields["post_title"] = name
-                        if should_update_description and description_text:
-                            update_fields["post_content"] = description_text
-                        if update_fields:
-                            woo_client.post_update(product_id, **update_fields)
-                        if brand and (not before.get("brand") or before.get("brand") != brand):
-                            woo_client.set_brand(product_id, brand)
-                        if category:
-                            woo_client.set_category(product_id, category)
-                        if should_update_image and image_source:
-                            woo_client.import_image(product_id, image_source)
-                    except WPCLIError as exc:
-                        entry["action"] = "error"
-                        entry["reason"] = format_wp_error(exc)
-                        skipped.append(entry)
-                        metrics["skipped"] += 1
-                        metrics["wp_errors"] += 1
-                        log.write(f"{sku}: error WP update → {exc}\n")
-                        continue
-                updated.append(entry)
-                metrics["updated"] += 1
-                log.write(
-                    f"{sku}: update → stock={stock_total} precio={precio_objetivo}"
-                    f" update_price={after_payload['update_price']}.\n"
-                )
-            else:
-                entry["action"] = "create"
-                if writer == "wp" and woo_client is not None:
-                    try:
-                        create_fields: Dict[str, str] = {"post_title": name or sku}
-                        if should_update_description and description_text:
-                            create_fields["post_content"] = description_text
-                        product_id = woo_client.post_create(**create_fields)
-                        woo_client.update_post_meta(product_id, "_sku", sku)
-                        woo_client.update_post_meta(product_id, "_manage_stock", "yes")
-                        woo_client.update_post_meta(product_id, "_stock", str(stock_total))
-                        woo_client.update_post_meta(
-                            product_id,
-                            "_stock_status",
-                            "instock" if stock_total > 0 else "outofstock",
-                        )
-                        if precio_objetivo > 0:
-                            price_text = format_price(precio_objetivo)
-                            woo_client.update_post_meta(product_id, "_price", price_text)
-                            woo_client.update_post_meta(product_id, "_regular_price", price_text)
-                        if weight is not None:
-                            woo_client.update_post_meta(product_id, "_weight", str(weight))
-                        if brand:
-                            woo_client.set_brand(product_id, brand)
-                        if category:
-                            woo_client.set_category(product_id, category)
-                        if should_update_image and image_source:
-                            woo_client.import_image(product_id, image_source)
-                    except WPCLIError as exc:
-                        entry["action"] = "error"
-                        entry["reason"] = format_wp_error(exc)
-                        skipped.append(entry)
-                        metrics["skipped"] += 1
-                        metrics["wp_errors"] += 1
-                        log.write(f"{sku}: error WP create → {exc}\n")
-                        continue
-                created.append(entry)
-                metrics["created"] += 1
-                log.write(
-                    f"{sku}: create → stock={stock_total} precio={precio_objetivo}.\n"
-                )
-
-        report_payload = {
-            "created": created,
-            "updated": updated,
-            "skipped": skipped,
-        }
-
-    with report_path.open("w", encoding="utf-8") as report:
-        json.dump(report_payload, report, indent=2, ensure_ascii=False, sort_keys=True)
-
-    update_summary(summary_paths, "stage_10", metrics)
-
-
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Stage 10 - WooCommerce import plan")
+    parser = argparse.ArgumentParser(description="Stage 10 - WooCommerce import")
     parser.add_argument("--run-dir", required=True)
     parser.add_argument("--input", required=True)
     parser.add_argument("--log", required=True)
@@ -769,7 +623,465 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--writer", choices=["sim", "wp"], default=None)
     parser.add_argument("--wp-path", default=None)
     parser.add_argument("--wp-args", default=None)
+    parser.add_argument("--run-id", default="")
     return parser.parse_args()
+
+
+def collect_summary_paths(run_dir: Path, explicit: Iterable[str]) -> List[Path]:
+    summary_paths = [Path(item) for item in explicit] if explicit else []
+    if not summary_paths:
+        summary_paths = [run_dir / "summary.json", run_dir / "final" / "summary.json"]
+    return summary_paths
+
+
+def detect_existing_sim(record: Mapping[str, Any]) -> Tuple[bool, Optional[int]]:
+    for key in ("woo_product_id", "product_id", "woo_id", "post_id"):
+        pid = parse_int(record.get(key), 0)
+        if pid > 0:
+            return True, pid
+    for key in ("woo_exists", "exists_in_woo", "exists"):
+        value = record.get(key)
+        if isinstance(value, bool) and value:
+            return True, None
+        if isinstance(value, str) and value.strip().lower() in {"1", "true", "yes", "y", "si", "sí"}:
+            return True, None
+    return False, None
+
+
+def ensure_flags(entry: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+    flags = entry.setdefault("flags", {})
+    for key in (
+        "category_assigned",
+        "brand_assigned",
+        "image_set",
+        "desc_set",
+        "price_set",
+        "stock_set",
+        "mirror_written",
+    ):
+        flags.setdefault(key, False)
+    return flags
+
+
+def stage10(args: argparse.Namespace) -> None:
+    run_dir = Path(args.run_dir)
+    input_path = Path(args.input)
+    log_path = Path(args.log)
+    report_path = Path(args.report)
+    dry_run = bool(args.dry_run)
+    summary_paths = collect_summary_paths(run_dir, args.summary)
+
+    writer = (args.writer or os.environ.get("IMPORT_WRITER") or os.environ.get("WRITER") or "sim").strip().lower()
+    if writer not in {"sim", "wp"}:
+        writer = "sim"
+    if writer == "wp" and dry_run and os.environ.get("FORCE_WRITE", "0") in {"1", "true", "yes"}:
+        dry_run = False
+
+    wp_path = args.wp_path or os.environ.get("WP_PATH", "wp")
+    wp_args = args.wp_args or os.environ.get("WP_PATH_ARGS", "")
+    write_enabled = writer == "wp" and not dry_run
+
+    ensure_parent_dir(log_path)
+    ensure_parent_dir(report_path)
+
+    with log_path.open("w", encoding="utf-8") as log:
+        log.write(f"== Stage 10: import (writer={writer})==\n")
+        log.write(f"Dry-run={'yes' if dry_run else 'no'}\n")
+
+        if not input_path.exists():
+            raise FileNotFoundError(f"No existe input: {input_path}")
+
+        records = list(read_jsonl(input_path))
+        total_records = len(records)
+        log.write(f"Registros a procesar: {total_records}\n")
+
+        woo_client = WooClient(wp_path, wp_args, log, write_enabled) if writer == "wp" else None
+        mirror_manager = MirrorManager(woo_client, log, args.run_id or run_dir.name) if woo_client else None
+
+        metrics: Dict[str, Any] = {
+            "rows_total": total_records,
+            "created": 0,
+            "updated": 0,
+            "skipped": 0,
+            "price_zero": 0,
+            "stock_zero": 0,
+            "wp_errors": 0,
+            "mirror_written": 0,
+            "mirror_partial": 0,
+            "mirror_skipped": 0,
+        }
+
+        created_entries: List[Dict[str, Any]] = []
+        updated_entries: List[Dict[str, Any]] = []
+        skipped_entries: List[Dict[str, Any]] = []
+
+        for record in records:
+            sku = str(record.get("sku") or record.get("SKU") or "").strip()
+            if not sku:
+                log.write("registro sin SKU, skip\n")
+                metrics["skipped"] += 1
+                skipped_entries.append({"sku": None, "action": "skipped", "reason": "missing_sku", "flags": {}})
+                continue
+
+            name = build_name(record)
+            brand = str(record.get("Marca", "")).strip()
+            category_raw = record.get("ID_Menu_Nvl_3")
+            description = extract_description(record)
+            image_source = extract_image_source(record)
+            weight = parse_float(record.get("Peso_Kg"), -1.0)
+            weight = round(weight, 3) if weight >= 0 else None
+
+            stock_info = compute_stock_info(record)
+            stock_total = stock_info["stock_total_mayoristas"]
+            precio_objetivo = parse_float(record.get("price_16_final"), 0.0)
+
+            entry: Dict[str, Any] = {
+                "sku": sku,
+                "precio_objetivo": round(precio_objetivo, 2),
+                "stock_total_mayoristas": stock_total,
+                "before": {},
+                "after": {
+                    "name": name,
+                    "brand": brand,
+                    "category": category_raw,
+                    "stock": stock_total,
+                    "price": round(precio_objetivo, 2),
+                    "weight": weight,
+                },
+                "flags": {},
+            }
+            flags = ensure_flags(entry)
+
+            existing = False
+            product_id: Optional[int] = None
+            current_price = 0.0
+            current_stock = 0
+            current_brand = ""
+            current_category = ""
+            has_image = False
+            has_desc = False
+
+            if writer == "wp" and woo_client:
+                try:
+                    product_id = woo_client.find_product_id(sku)
+                except WPCLIError as exc:
+                    metrics["skipped"] += 1
+                    metrics["wp_errors"] += 1
+                    entry["action"] = "skipped"
+                    entry["reason"] = f"wp_error:{exc}"
+                    skipped_entries.append(entry)
+                    log.write(f"{sku}: error find_product_id → {exc}\n")
+                    continue
+                existing = product_id is not None
+                if existing and product_id:
+                    entry["after"]["product_id"] = product_id
+                    entry["before"]["product_id"] = product_id
+                    current_price = parse_float(woo_client.get_post_meta(product_id, "_regular_price"), 0.0)
+                    current_stock = parse_int(woo_client.get_post_meta(product_id, "_stock"), 0)
+                    entry["before"]["price"] = round(current_price, 2)
+                    entry["before"]["stock"] = current_stock
+                    terms_brand = woo_client.get_terms(product_id, "product_brand")
+                    if terms_brand:
+                        current_brand = str(terms_brand[0].get("name") or "")
+                        if current_brand:
+                            entry["before"]["brand"] = current_brand
+                    terms_cat = woo_client.get_terms(product_id, "product_cat")
+                    if terms_cat:
+                        term = terms_cat[0]
+                        term_id = term.get("term_id")
+                        entry["before"]["category"] = term_id or term.get("name")
+                        current_category = str(term_id or term.get("name") or "")
+                    has_image = woo_client.has_thumbnail(product_id)
+                    has_desc = woo_client.has_description(product_id)
+                else:
+                    has_image = False
+                    has_desc = False
+            else:
+                existing, product_id = detect_existing_sim(record)
+                current_price = parse_float(record.get("woo_regular_price"), 0.0)
+                current_stock = parse_int(record.get("woo_stock"), 0)
+                if existing:
+                    entry["before"] = {
+                        "product_id": product_id,
+                        "price": round(current_price, 2),
+                        "stock": current_stock,
+                        "brand": record.get("woo_brand"),
+                        "category": record.get("woo_category"),
+                    }
+                has_image = bool(record.get("woo_has_image"))
+                has_desc = bool(record.get("woo_has_description"))
+
+            should_update_description = bool(description) and not has_desc
+            should_set_image = bool(image_source) and not has_image
+
+            if precio_objetivo <= 0:
+                metrics["price_zero"] += 1
+                entry["reason"] = "price_zero"
+                if existing and writer == "wp" and woo_client and product_id:
+                    try:
+                        woo_client.update_post_meta(product_id, "_manage_stock", "yes")
+                        woo_client.update_post_meta(product_id, "_stock", "0")
+                        woo_client.update_post_meta(product_id, "_stock_status", "outofstock")
+                        flags["stock_set"] = True
+                    except WPCLIError as exc:
+                        metrics["wp_errors"] += 1
+                        entry["reason"] = f"wp_error:{exc}"
+                        entry["action"] = "skipped"
+                        skipped_entries.append(entry)
+                        log.write(f"{sku}: error al forzar stock=0 → {exc}\n")
+                        continue
+                    entry["action"] = "update"
+                    updated_entries.append(entry)
+                    metrics["updated"] += 1
+                    log.write(f"{sku}: precio objetivo 0 → stock forzado a 0.\n")
+                elif existing:
+                    entry["action"] = "update"
+                    flags["stock_set"] = True
+                    updated_entries.append(entry)
+                    metrics["updated"] += 1
+                    log.write(f"{sku}: precio 0 (simulación) → stock=0.\n")
+                else:
+                    entry["action"] = "skipped"
+                    skipped_entries.append(entry)
+                    metrics["skipped"] += 1
+                    log.write(f"{sku}: precio 0, no se crea.\n")
+                continue
+
+            if stock_total <= 0:
+                metrics["stock_zero"] += 1
+                entry["reason"] = "stock_zero"
+                if existing and writer == "wp" and woo_client and product_id:
+                    try:
+                        woo_client.update_post_meta(product_id, "_manage_stock", "yes")
+                        woo_client.update_post_meta(product_id, "_stock", "0")
+                        woo_client.update_post_meta(product_id, "_stock_status", "outofstock")
+                        flags["stock_set"] = True
+                    except WPCLIError as exc:
+                        metrics["wp_errors"] += 1
+                        entry["reason"] = f"wp_error:{exc}"
+                        entry["action"] = "skipped"
+                        skipped_entries.append(entry)
+                        log.write(f"{sku}: error al poner stock=0 → {exc}\n")
+                        continue
+                    entry["action"] = "update"
+                    updated_entries.append(entry)
+                    metrics["updated"] += 1
+                    log.write(f"{sku}: sin stock → stock=0 actualizado.\n")
+                elif existing:
+                    entry["action"] = "update"
+                    flags["stock_set"] = True
+                    updated_entries.append(entry)
+                    metrics["updated"] += 1
+                    log.write(f"{sku}: sin stock (sim) → stock=0.\n")
+                else:
+                    entry["action"] = "skipped"
+                    skipped_entries.append(entry)
+                    metrics["skipped"] += 1
+                    log.write(f"{sku}: sin stock, no se crea.\n")
+                continue
+
+            price_set = False
+            stock_set = False
+            desc_set = False
+            image_set = False
+            category_assigned = False
+            brand_assigned = False
+            mirror_status = "skipped"
+
+            category_term_id: Optional[int] = None
+            category_slug = ""
+
+            if existing:
+                if product_id:
+                    entry["after"]["product_id"] = product_id
+                entry["action"] = "update"
+                if writer == "wp" and woo_client and product_id:
+                    try:
+                        woo_client.update_post_meta(product_id, "_sku", sku)
+                        woo_client.update_post_meta(product_id, "_manage_stock", "yes")
+                        woo_client.update_post_meta(product_id, "_stock", str(stock_total))
+                        woo_client.update_post_meta(
+                            product_id,
+                            "_stock_status",
+                            "instock" if stock_total > 0 else "outofstock",
+                        )
+                        stock_set = True
+                        if weight is not None:
+                            woo_client.update_post_meta(product_id, "_weight", str(weight))
+                        if should_update_description:
+                            woo_client.post_update(product_id, post_content=description)
+                            desc_set = True
+                        if name and woo_client.get_post_field(product_id, "post_title") != name:
+                            woo_client.post_update(product_id, post_title=name)
+                        if should_set_image:
+                            woo_client.import_image(product_id, image_source)
+                            image_set = True
+                        # Price guard: only lower or equal
+                        if current_price <= 0 or precio_objetivo <= current_price:
+                            price_text = format_price(precio_objetivo)
+                            woo_client.update_post_meta(product_id, "_price", price_text)
+                            woo_client.update_post_meta(product_id, "_regular_price", price_text)
+                            price_set = True
+                        else:
+                            log.write(
+                                f"{sku}: precio nuevo ({precio_objetivo}) > actual ({current_price}), no se actualiza precio.\n"
+                            )
+                        if brand:
+                            term_id = woo_client.ensure_brand(brand)
+                            if term_id:
+                                woo_client.set_terms("product_brand", product_id, term_id)
+                                brand_assigned = True
+                        if category_raw is not None:
+                            category_term_id = woo_client.ensure_category(category_raw)
+                            if category_term_id:
+                                woo_client.set_terms("product_cat", product_id, category_term_id)
+                                category_assigned = True
+                                category_slug = slugify(str(category_raw if not isinstance(category_raw, list) else category_raw[-1]))
+                    except WPCLIError as exc:
+                        metrics["wp_errors"] += 1
+                        entry["reason"] = f"wp_error:{exc}"
+                        entry["action"] = "skipped"
+                        skipped_entries.append(entry)
+                        log.write(f"{sku}: error update → {exc}\n")
+                        continue
+                else:
+                    stock_set = True
+                    desc_set = should_update_description
+                    image_set = should_set_image
+                    if precio_objetivo <= current_price or current_price <= 0:
+                        price_set = True
+                    else:
+                        log.write(
+                            f"{sku}: (sim) precio nuevo {precio_objetivo} > actual {current_price}, no se actualiza.\n"
+                        )
+                    category_assigned = category_raw is not None
+                    brand_assigned = bool(brand)
+                metrics["updated"] += 1
+                updated_entries.append(entry)
+            else:
+                entry["action"] = "create"
+                if writer == "wp" and woo_client:
+                    try:
+                        create_fields = {"post_title": name or sku}
+                        if should_update_description:
+                            create_fields["post_content"] = description
+                        product_id = woo_client.post_create(**create_fields)
+                        entry["after"]["product_id"] = product_id
+                        woo_client.update_post_meta(product_id, "_sku", sku)
+                        woo_client.update_post_meta(product_id, "_manage_stock", "yes")
+                        woo_client.update_post_meta(product_id, "_stock", str(stock_total))
+                        woo_client.update_post_meta(
+                            product_id,
+                            "_stock_status",
+                            "instock" if stock_total > 0 else "outofstock",
+                        )
+                        stock_set = True
+                        if precio_objetivo > 0:
+                            price_text = format_price(precio_objetivo)
+                            woo_client.update_post_meta(product_id, "_price", price_text)
+                            woo_client.update_post_meta(product_id, "_regular_price", price_text)
+                            price_set = True
+                        if weight is not None:
+                            woo_client.update_post_meta(product_id, "_weight", str(weight))
+                        if brand:
+                            term_id = woo_client.ensure_brand(brand)
+                            if term_id:
+                                woo_client.set_terms("product_brand", product_id, term_id)
+                                brand_assigned = True
+                        if category_raw is not None:
+                            category_term_id = woo_client.ensure_category(category_raw)
+                            if category_term_id:
+                                woo_client.set_terms("product_cat", product_id, category_term_id)
+                                category_assigned = True
+                                category_slug = slugify(
+                                    str(category_raw if not isinstance(category_raw, list) else category_raw[-1])
+                                )
+                        if should_set_image:
+                            woo_client.import_image(product_id, image_source)
+                            image_set = True
+                        if not should_update_description and description and not desc_set:
+                            # ensure description if provided but product had none
+                            woo_client.post_update(product_id, post_content=description)
+                            desc_set = True
+                        else:
+                            desc_set = should_update_description
+                    except WPCLIError as exc:
+                        metrics["wp_errors"] += 1
+                        entry["reason"] = f"wp_error:{exc}"
+                        entry["action"] = "skipped"
+                        skipped_entries.append(entry)
+                        log.write(f"{sku}: error create → {exc}\n")
+                        continue
+                else:
+                    stock_set = True
+                    price_set = True
+                    desc_set = should_update_description
+                    image_set = should_set_image
+                    category_assigned = category_raw is not None
+                    brand_assigned = bool(brand)
+                metrics["created"] += 1
+                created_entries.append(entry)
+
+            flags["price_set"] = price_set
+            flags["stock_set"] = stock_set
+            flags["desc_set"] = desc_set
+            flags["image_set"] = image_set
+            flags["category_assigned"] = category_assigned
+            flags["brand_assigned"] = brand_assigned
+
+            if category_term_id:
+                entry["after"]["category"] = category_term_id
+
+            product_payload = {
+                "name": name,
+                "brand": brand,
+                "category_id": category_term_id,
+                "category_slug": category_slug,
+                "weight": weight,
+                "stock": stock_total,
+                "image_set": image_set,
+            }
+
+            if writer == "wp" and woo_client and mirror_manager and entry["action"] != "skipped":
+                try:
+                    status = mirror_manager.apply(sku, record, product_payload)
+                except WPCLIError as exc:
+                    status = "partial"
+                    metrics["wp_errors"] += 1
+                    log.write(f"{sku}: mirror error → {exc}\n")
+                if status == "written":
+                    metrics["mirror_written"] += 1
+                    flags["mirror_written"] = True
+                elif status == "partial":
+                    metrics["mirror_partial"] += 1
+                else:
+                    metrics["mirror_skipped"] += 1
+            else:
+                flags["mirror_written"] = False
+
+            log_parts = [
+                f"action={entry['action']}",
+                f"price_set={price_set}",
+                f"stock_set={stock_set}",
+                f"desc={desc_set}",
+                f"image={image_set}",
+                f"brand={brand_assigned}",
+                f"cat={category_assigned}",
+            ]
+            if flags.get("mirror_written"):
+                log_parts.append("mirror=written")
+            log.write(f"{sku}: " + " ".join(log_parts) + "\n")
+
+        report_payload = {
+            "created": created_entries,
+            "updated": updated_entries,
+            "skipped": skipped_entries,
+        }
+
+    with report_path.open("w", encoding="utf-8") as fh:
+        json.dump(report_payload, fh, indent=2, ensure_ascii=False, sort_keys=True)
+
+    update_summary(summary_paths, "stage_10", metrics)
 
 
 if __name__ == "__main__":

--- a/python/stage11_postcheck.py
+++ b/python/stage11_postcheck.py
@@ -15,7 +15,7 @@ class WPCLIError(RuntimeError):
     """Raised when a WP-CLI command fails."""
 
 
-class WooReader:
+class WooInspector:
     def __init__(self, wp_path: str, wp_args: str) -> None:
         self.wp_path = wp_path or "wp"
         self.wp_args = shlex.split(wp_args) if wp_args else []
@@ -91,31 +91,76 @@ class WooReader:
             data = json.loads(result.stdout or "[]")
         except json.JSONDecodeError:
             return []
+        terms: List[Dict[str, Any]] = []
         if isinstance(data, list):
-            return [item for item in data if isinstance(item, Mapping)]
-        return []
+            for item in data:
+                if isinstance(item, Mapping):
+                    terms.append(dict(item))
+        return terms
+
+    def db_query(self, sql: str) -> subprocess.CompletedProcess:
+        return self.run(["db", "query", sql, "--skip-column-names"], check=False)
+
+
+class MirrorInspector:
+    def __init__(self, inspector: WooInspector, log) -> None:
+        self.inspector = inspector
+        self.log = log
+        self._detected = False
+        self._tables: Dict[str, bool] = {}
+
+    def detect(self) -> None:
+        if self._detected:
+            return
+        self._detected = True
+        try:
+            result = self.inspector.db_query("SHOW TABLES LIKE 'wp_compu_%';")
+        except WPCLIError as exc:
+            if self.log:
+                self.log.write(f"mirror detect error: {exc}\n")
+            return
+        tables = set(line.strip() for line in (result.stdout or "").splitlines() if line.strip())
+        for name in ("wp_compu_products", "wp_compu_prices", "wp_compu_inventory"):
+            self._tables[name] = name in tables
+
+    def sku_present(self, table: str, sku: str) -> bool:
+        self.detect()
+        if not self._tables.get(table):
+            return True
+        sku_text = str(sku).replace("'", "''")
+        result = self.inspector.db_query(
+            f"SELECT 1 FROM {table} WHERE sku = '{sku_text}' LIMIT 1;"
+        )
+        if result.returncode != 0:
+            if self.log:
+                self.log.write(
+                    f"mirror query error ({table}): rc={result.returncode} stderr={result.stderr.strip()}\n"
+                )
+            return False
+        return bool((result.stdout or "").strip())
+
+    def all_present(self, sku: str) -> bool:
+        self.detect()
+        for table, enabled in self._tables.items():
+            if not enabled:
+                continue
+            if not self.sku_present(table, sku):
+                return False
+        return True
+
+    @property
+    def enabled(self) -> bool:
+        self.detect()
+        return any(self._tables.values())
 
 
 def format_wp_error(exc: Exception) -> str:
-    message = str(exc).strip().replace("\r", " ").replace("\n", " ")
-    message = " ".join(message.split())
+    message = str(exc).strip().replace("\n", " ").replace("\r", " ")
     return f"wp_error:{message}" if message else "wp_error:unknown"
 
 
-def to_bool(value: Any) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return bool(value)
-    if isinstance(value, str):
-        text = value.strip().lower()
-        if text in {"1", "true", "yes", "y", "si", "sí"}:
-            return True
-    return False
-
-
 def ensure_summary_paths(run_dir: Path, explicit: Iterable[str]) -> List[Path]:
-    summary_paths = [Path(p) for p in explicit] if explicit else []
+    summary_paths = [Path(path) for path in explicit] if explicit else []
     if not summary_paths:
         summary_paths = [run_dir / "summary.json", run_dir / "final" / "summary.json"]
     return summary_paths
@@ -133,11 +178,7 @@ def load_import_report(path: Path) -> Mapping[str, List[Mapping[str, Any]]]:
     skipped = data.get("skipped")
     if not isinstance(created, list) or not isinstance(updated, list) or not isinstance(skipped, list):
         raise ValueError("Estructura inesperada en import-report.json")
-    return {
-        "created": created,
-        "updated": updated,
-        "skipped": skipped,
-    }
+    return {"created": created, "updated": updated, "skipped": skipped}
 
 
 def collect_samples(created: List[Mapping[str, Any]], updated: List[Mapping[str, Any]]) -> List[Dict[str, Any]]:
@@ -146,42 +187,23 @@ def collect_samples(created: List[Mapping[str, Any]], updated: List[Mapping[str,
         return []
     rng = random.Random(42)
     sample_size = min(20, len(pool))
-    selection = rng.sample(pool, sample_size)
+    picks = rng.sample(pool, sample_size)
     samples: List[Dict[str, Any]] = []
-    for item in selection:
+    for item in picks:
         after = item.get("after") if isinstance(item.get("after"), Mapping) else {}
         samples.append(
             {
                 "sku": item.get("sku"),
-                "name": after.get("name"),
-                "price": after.get("price"),
-                "stock": after.get("stock"),
-                "category": after.get("category"),
-                "image_set": after.get("set_image"),
-                "brand": after.get("brand"),
                 "action": item.get("action"),
                 "reason": item.get("reason"),
+                "expected_price": parse_float(after.get("price"), 0.0),
+                "expected_stock": parse_int(after.get("stock"), 0),
+                "expected_category": after.get("category"),
+                "expected_brand": after.get("brand"),
+                "expected_weight": parse_float(after.get("weight"), 0.0),
             }
         )
     return samples
-
-
-def price_zero_guard_items(report: Mapping[str, List[Mapping[str, Any]]]) -> List[Dict[str, Any]]:
-    items: List[Dict[str, Any]] = []
-    for bucket in ("created", "updated", "skipped"):
-        for entry in report.get(bucket, []):
-            if not isinstance(entry, Mapping):
-                continue
-            if entry.get("reason") == "price_zero":
-                items.append(
-                    {
-                        "sku": entry.get("sku"),
-                        "action": entry.get("action"),
-                        "precio_objetivo": entry.get("precio_objetivo"),
-                        "stock_total_mayoristas": entry.get("stock_total_mayoristas"),
-                    }
-                )
-    return items
 
 
 def stage11(args: argparse.Namespace) -> None:
@@ -190,22 +212,20 @@ def stage11(args: argparse.Namespace) -> None:
     report_path = Path(args.import_report)
     postcheck_path = Path(args.postcheck)
     dry_run = bool(args.dry_run)
-    run_id = args.run_id or run_dir.name
     summary_paths = ensure_summary_paths(run_dir, args.summary)
 
-    env_writer = (args.writer or os.environ.get("IMPORT_WRITER") or os.environ.get("WRITER") or "sim").strip().lower()
-    writer = env_writer if env_writer in {"sim", "wp"} else "sim"
-    if writer == "wp" and dry_run and to_bool(os.environ.get("FORCE_WRITE")):
-        dry_run = False
+    writer = (args.writer or os.environ.get("IMPORT_WRITER") or os.environ.get("WRITER") or "sim").strip().lower()
+    if writer not in {"sim", "wp"}:
+        writer = "sim"
+    real_mode = writer == "wp" and not dry_run
+
     wp_path = args.wp_path or os.environ.get("WP_PATH", "wp")
     wp_args = args.wp_args or os.environ.get("WP_PATH_ARGS", "")
-    real_mode = writer == "wp" and not dry_run
 
     ensure_parent_dir(log_path)
     ensure_parent_dir(postcheck_path)
 
     report = load_import_report(report_path)
-
     created = report.get("created", [])
     updated = report.get("updated", [])
     skipped = report.get("skipped", [])
@@ -216,196 +236,245 @@ def stage11(args: argparse.Namespace) -> None:
         "skipped": len(skipped),
     }
 
-    price_zero_items = price_zero_guard_items(report)
-
     samples = collect_samples(created, updated)
 
     diffs: List[Dict[str, Any]] = []
-    wp_error_count = 0
+    wp_errors = 0
+    check_counts = {
+        "samples_total": len(samples),
+        "product_found": 0,
+        "category_present": 0,
+        "brand_present": 0,
+        "image_present": 0,
+        "price_match": 0,
+        "stock_match": 0,
+        "weight_match": 0,
+        "mirrors_present": 0,
+    }
 
-    woo_reader = WooReader(wp_path, wp_args) if real_mode else None
+    inspector = WooInspector(wp_path, wp_args) if real_mode else None
+    mirror = MirrorInspector(inspector, None) if inspector else None
 
     with log_path.open("w", encoding="utf-8") as log:
-        log.write(f"== Stage 11: post-import check (writer={writer})==\n")
+        log.write(f"== Stage 11: postcheck (writer={writer})==\n")
         log.write(f"Dry-run={'yes' if dry_run else 'no'}\n")
         log.write(
             f"Conteos → created={counts['created']} updated={counts['updated']} skipped={counts['skipped']}\n"
         )
-        if price_zero_items:
-            log.write(f"Guardas price_zero: {len(price_zero_items)} casos.\n")
-        if real_mode and woo_reader is not None:
-            log.write("Modo real: consultando WooCommerce vía WP-CLI.\n")
+        if not samples:
+            log.write("Sin muestras para verificar.\n")
+        if real_mode:
+            log.write("Modo real: usando WP-CLI para verificaciones.\n")
+        else:
+            log.write("Modo simulación: verificación sólo contra import-report.\n")
+
+        if real_mode and inspector is not None:
+            mirror = MirrorInspector(inspector, log)
             for sample in samples:
                 sku = str(sample.get("sku") or "").strip()
                 if not sku:
                     continue
                 try:
-                    product_id = woo_reader.find_product_id(sku)
+                    product_id = inspector.find_product_id(sku)
                 except WPCLIError as exc:
-                    sample["woo_error"] = format_wp_error(exc)
-                    diffs.append(
-                        {
-                            "sku": sku,
-                            "field": "product_id",
-                            "expected": "exists",
-                            "actual": "wp_error",
-                        }
-                    )
-                    wp_error_count += 1
-                    log.write(f"{sku}: error consultando Woo → {exc}\n")
+                    wp_errors += 1
+                    diff = {"sku": sku, "field": "product_id", "expected": "exists", "actual": format_wp_error(exc)}
+                    diffs.append(diff)
+                    sample["error"] = format_wp_error(exc)
+                    log.write(f"{sku}: error al buscar producto → {exc}\n")
                     continue
                 if not product_id:
-                    sample["woo_found"] = False
-                    diffs.append(
-                        {
-                            "sku": sku,
-                            "field": "product_id",
-                            "expected": "exists",
-                            "actual": "missing",
-                        }
-                    )
-                    log.write(f"{sku}: producto no encontrado en Woo.\n")
+                    diff = {"sku": sku, "field": "product_id", "expected": "exists", "actual": "missing"}
+                    diffs.append(diff)
+                    sample["product_id"] = None
+                    log.write(f"{sku}: producto no encontrado.\n")
                     continue
 
-                sample["woo_found"] = True
-                log.write(f"{sku}: verificación en Woo ID {product_id}.\n")
+                sample["product_id"] = product_id
+                check_counts["product_found"] += 1
+                log.write(f"{sku}: verificación producto {product_id}.\n")
 
-                actual_name = woo_reader.get_post_field(product_id, "post_title")
-                actual_name = (actual_name or "").strip()
-                actual_price_value = parse_float(
-                    woo_reader.get_post_meta(product_id, "_price"), 0.0
+                actual_name = inspector.get_post_field(product_id, "post_title")
+                actual_price = parse_float(inspector.get_post_meta(product_id, "_regular_price"), 0.0)
+                actual_stock = parse_int(inspector.get_post_meta(product_id, "_stock"), 0)
+                actual_weight = parse_float(inspector.get_post_meta(product_id, "_weight"), 0.0)
+                thumbnail_id = inspector.get_post_meta(product_id, "_thumbnail_id")
+
+                brand_terms = inspector.get_terms(product_id, "product_brand")
+                category_terms = inspector.get_terms(product_id, "product_cat")
+
+                sample.update(
+                    {
+                        "woo_name": actual_name,
+                        "woo_price": round(actual_price, 2),
+                        "woo_stock": actual_stock,
+                        "woo_weight": actual_weight,
+                        "woo_brand": brand_terms[0].get("name") if brand_terms else "",
+                        "woo_category": category_terms[0].get("term_id") if category_terms else None,
+                        "woo_thumbnail": thumbnail_id,
+                    }
                 )
-                actual_stock_value = parse_int(
-                    woo_reader.get_post_meta(product_id, "_stock"), 0
-                )
-                brand_terms = woo_reader.get_terms(product_id, "product_brand")
-                actual_brand = ""
+
                 if brand_terms:
+                    expected_brand = str(sample.get("expected_brand") or "").strip()
                     actual_brand = str(brand_terms[0].get("name") or "").strip()
-                cat_terms = woo_reader.get_terms(product_id, "product_cat")
-                actual_category = ""
-                if cat_terms:
-                    term = cat_terms[0]
-                    actual_category = str(
-                        term.get("term_id") or term.get("name") or ""
-                    ).strip()
-
-                sample["woo_name"] = actual_name
-                sample["woo_price"] = round(actual_price_value, 2)
-                sample["woo_stock"] = actual_stock_value
-                sample["woo_brand"] = actual_brand
-                sample["woo_category"] = actual_category
-
-                expected_name = str(sample.get("name") or "").strip()
-                expected_price_value = round(parse_float(sample.get("price"), 0.0), 2)
-                expected_stock_value = parse_int(sample.get("stock"), 0)
-                expected_brand = str(sample.get("brand") or "").strip()
-                expected_category = str(sample.get("category") or "").strip()
-
-                if expected_name and actual_name != expected_name:
-                    diffs.append(
-                        {
-                            "sku": sku,
-                            "field": "name",
-                            "expected": expected_name,
-                            "actual": actual_name,
-                        }
-                    )
-
-                guard_price_zero = sample.get("reason") == "price_zero"
-                if guard_price_zero:
-                    sample["price_guard"] = True
-                else:
-                    if expected_price_value != round(actual_price_value, 2):
+                    if expected_brand and expected_brand.lower() != actual_brand.lower():
                         diffs.append(
                             {
                                 "sku": sku,
-                                "field": "price",
-                                "expected": expected_price_value,
-                                "actual": round(actual_price_value, 2),
+                                "field": "brand",
+                                "expected": expected_brand,
+                                "actual": actual_brand or "missing",
                             }
                         )
-
-                if expected_stock_value != actual_stock_value:
-                    diffs.append(
-                        {
-                            "sku": sku,
-                            "field": "stock",
-                            "expected": expected_stock_value,
-                            "actual": actual_stock_value,
-                        }
-                    )
-
-                if expected_brand and actual_brand != expected_brand:
+                    else:
+                        check_counts["brand_present"] += 1
+                else:
                     diffs.append(
                         {
                             "sku": sku,
                             "field": "brand",
-                            "expected": expected_brand,
-                            "actual": actual_brand,
+                            "expected": sample.get("expected_brand"),
+                            "actual": "missing",
                         }
                     )
 
-                if expected_category and actual_category != expected_category:
+                if category_terms:
+                    check_counts["category_present"] += 1
+                    expected_category = sample.get("expected_category")
+                    actual_term = category_terms[0]
+                    actual_candidates = {
+                        str(actual_term.get("term_id")),
+                        actual_term.get("term_id"),
+                        str(actual_term.get("slug") or ""),
+                        str(actual_term.get("name") or ""),
+                    }
+                    expected_candidates = set()
+                    if isinstance(expected_category, list):
+                        for item in expected_category:
+                            expected_candidates.add(item)
+                            expected_candidates.add(str(item))
+                    elif expected_category not in {None, ""}:
+                        expected_candidates.add(expected_category)
+                        expected_candidates.add(str(expected_category))
+                    if expected_candidates and actual_candidates.isdisjoint(expected_candidates):
+                        diffs.append(
+                            {
+                                "sku": sku,
+                                "field": "category",
+                                "expected": expected_category,
+                                "actual": actual_term.get("term_id"),
+                            }
+                        )
+                else:
                     diffs.append(
                         {
                             "sku": sku,
                             "field": "category",
-                            "expected": expected_category,
-                            "actual": actual_category,
+                            "expected": sample.get("expected_category"),
+                            "actual": "missing",
                         }
                     )
-        else:
-            log.write("Modo simulación (sin consulta a Woo).\n")
+
+                if thumbnail_id:
+                    check_counts["image_present"] += 1
+                else:
+                    diffs.append({"sku": sku, "field": "image", "expected": "featured", "actual": "missing"})
+
+                guard_price_zero = sample.get("reason") == "price_zero"
+                expected_price = round(sample.get("expected_price", 0.0), 2)
+                if guard_price_zero:
+                    if actual_stock != 0:
+                        diffs.append(
+                            {
+                                "sku": sku,
+                                "field": "stock",
+                                "expected": 0,
+                                "actual": actual_stock,
+                            }
+                        )
+                    else:
+                        check_counts["stock_match"] += 1
+                else:
+                    if round(actual_price, 2) > expected_price + 0.01:
+                        diffs.append(
+                            {
+                                "sku": sku,
+                                "field": "price",
+                                "expected": expected_price,
+                                "actual": round(actual_price, 2),
+                            }
+                        )
+                    else:
+                        check_counts["price_match"] += 1
+                    expected_stock = sample.get("expected_stock", 0)
+                    if actual_stock != expected_stock:
+                        diffs.append(
+                            {
+                                "sku": sku,
+                                "field": "stock",
+                                "expected": expected_stock,
+                                "actual": actual_stock,
+                            }
+                        )
+                    else:
+                        check_counts["stock_match"] += 1
+
+                expected_weight = sample.get("expected_weight")
+                if expected_weight:
+                    if abs(expected_weight - actual_weight) < 0.001:
+                        check_counts["weight_match"] += 1
+                    else:
+                        diffs.append(
+                            {
+                                "sku": sku,
+                                "field": "weight",
+                                "expected": expected_weight,
+                                "actual": actual_weight,
+                            }
+                        )
+
+                if mirror and mirror.enabled:
+                    if mirror.all_present(sku):
+                        check_counts["mirrors_present"] += 1
+                    else:
+                        diffs.append(
+                            {
+                                "sku": sku,
+                                "field": "mirror",
+                                "expected": "synced",
+                                "actual": "missing",
+                            }
+                        )
+        elif samples:
+            log.write("Saltando validaciones reales por modo simulación.\n")
 
         if diffs:
-            log.write(f"Se detectaron {len(diffs)} diferencias.\n")
+            log.write(f"Total diferencias detectadas: {len(diffs)}\n")
         else:
-            if real_mode:
-                log.write("Sin diferencias detectadas contra Woo.\n")
-            else:
-                log.write("Sin diferencias detectadas (modo simulación).\n")
+            log.write("Sin diferencias detectadas.\n")
 
     postcheck_payload = {
-        "counts": counts,
-        "samples": samples,
-        "diffs": diffs,
-        "price_zero_guard": price_zero_items,
         "mode": "wp" if real_mode else "simulation",
         "writer": writer,
-        "wp_errors": wp_error_count,
+        "diffs": len(diffs),
+        "checks": check_counts,
+        "samples": samples,
+        "issues": diffs,
+        "wp_errors": wp_errors,
     }
 
     with postcheck_path.open("w", encoding="utf-8") as fh:
         json.dump(postcheck_payload, fh, indent=2, ensure_ascii=False, sort_keys=True)
-
-    # README para docs
-    readme_dir = run_dir / "docs" / "runs" / run_id / "step-11"
-    ensure_parent_dir(readme_dir / "dummy")
-    readme_path = readme_dir / "README.md"
-    with readme_path.open("w", encoding="utf-8") as readme:
-        readme.write(f"# Stage 11 - Postcheck (writer={writer})\n\n")
-        readme.write(f"- Run ID: {run_id}\n")
-        readme.write(f"- Dry-run: {'sí' if dry_run else 'no'}\n")
-        readme.write(f"- Modo: {'Woo real' if real_mode else 'Simulación'}\n")
-        readme.write(
-            f"- Conteos: created={counts['created']} updated={counts['updated']} skipped={counts['skipped']}\n"
-        )
-        readme.write(f"- Casos price_zero: {len(price_zero_items)}\n")
-        readme.write(f"- Diferencias detectadas: {len(diffs)}\n")
-        if real_mode:
-            readme.write(f"- WP-CLI errores: {wp_error_count}\n")
 
     metrics = {
         "rows_total": counts["created"] + counts["updated"] + counts["skipped"],
         "created": counts["created"],
         "updated": counts["updated"],
         "skipped": counts["skipped"],
-        "price_zero": len(price_zero_items),
         "diffs": len(diffs),
+        "wp_errors": wp_errors,
         "mode": "wp" if real_mode else "simulation",
-        "writer": writer,
-        "wp_errors": wp_error_count,
     }
 
     update_summary(summary_paths, "stage_11", metrics)
@@ -418,8 +487,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--postcheck", required=True)
     parser.add_argument("--log", required=True)
     parser.add_argument("--dry-run", type=int, choices=[0, 1], default=1)
-    parser.add_argument("--run-id", default="")
     parser.add_argument("--summary", action="append", default=[])
+    parser.add_argument("--run-id", default="")
     parser.add_argument("--writer", choices=["sim", "wp"], default=None)
     parser.add_argument("--wp-path", default=None)
     parser.add_argument("--wp-args", default=None)


### PR DESCRIPTION
## Summary
- implement the Stage 10 writer that pushes products to WooCommerce via WP-CLI, applying pricing and stock guardrails, taxonomy assignments, featured images, and optional mirror table upserts
- add a real Stage 11 verifier that samples recent creations/updates, checks taxonomy, price, stock, media, and mirror entries, and reports differences
- refresh the stage10/11 test runner and README with the new workflow and validation expectations

## Testing
- tests/run_stage10_11.sh

------
https://chatgpt.com/codex/tasks/task_b_68e8e5de23dc8320b4761c99a02e6b7f