### PR TITLE
Add Compustar import orchestrator tooling

### DIFF
--- a/docs/runbook-import.md
+++ b/docs/runbook-import.md
@@ -1,0 +1,178 @@
+# Runbook — Orquestador de importación Compustar
+
+## 1. Descripción general
+
+El script `scripts/run_compustar_import.sh` ejecuta en secuencia los Stages 01 a 11 del pipeline **Compustar LEGO** dentro de un único RUN, asegurando exclusión mutua (`flock`), logging detallado y parametrización para ejecuciones completas o parciales. Cada etapa produce artefactos que alimentan a la siguiente, con validaciones estrictas tras cada paso.
+
+| Stage | Herramienta            | Descripción resumida                                 | Artefactos clave                          |
+|-------|------------------------|------------------------------------------------------|-------------------------------------------|
+| 01    | PHP (stage_runner)     | Copia el CSV fuente al RUN (`source.csv`).           | `source.csv`                              |
+| 02    | PHP (stage_runner)     | Normaliza encabezados y registros.                   | `normalized.jsonl`                        |
+| 03    | PHP (stage_runner)     | Valida registros normalizados.                       | `validated.jsonl`                         |
+| 04    | Python                 | Resuelve el mapeo de categorías contra `compu_cats_map`. | `resolved.jsonl`, métricas y reportes     |
+| 05    | WP-CLI `eval-file`     | Enlaza términos existentes sin crear categorías.     | `terms_resolved.jsonl` (auxiliar)         |
+| 06    | PHP                    | Prepara productos para importación.                  | Artefactos intermedios en el RUN          |
+| 07    | WP-CLI `eval-file`     | Gestiona media/imágenes del catálogo.                | `media.jsonl`, `media/`                   |
+| 08    | WP-CLI `eval-file`     | (Opcional) Precios/ofertas.                          | `final/offers_*` (si aplica)              |
+| 09    | WP-CLI `eval-file`     | (Opcional) Stock/actualizaciones de pricing.         | `final/pricing_*` (si aplica)             |
+| 10    | Python                 | Importa productos en WooCommerce (`writer=wp`).      | `final/import-report.json`, logs          |
+| 11    | Python                 | Auditoría post-import.                               | `final/postcheck.json`                    |
+
+Todos los artefactos se generan en `wp-content/uploads/compu-import/run-<epoch>` dentro de la instalación de WordPress.
+
+## 2. Instalación y requisitos
+
+1. **Ubicación de scripts**: el orquestador reside en `scripts/run_compustar_import.sh` dentro del repositorio `/home/compustar/compustar-project`.
+2. **Permisos**: otorgar permisos de ejecución.
+   ```bash
+   chmod +x /home/compustar/compustar-project/scripts/run_compustar_import.sh
+   chmod +x /home/compustar/compustar-project/tests/smoke_import.sh
+   ```
+3. **Dependencias** (verificadas en el `preflight`):
+   - `wp` (`/usr/local/bin/wp`)
+   - `php`
+   - `python3`
+   - `jq`
+4. **WordPress**: ruta base `/home/compustar/htdocs` con plugin `compu-import-lego` instalado.
+5. **Hotfix requerido**: el script aplica automáticamente la vista `wp_compu_cats_map` → `compu_cats_map` para entornos donde el prefijo `wp_` es obligatorio.
+
+## 3. Variables y parámetros
+
+### 3.1 CLI
+
+| Opción             | Descripción                                                          | Default                                      |
+|--------------------|----------------------------------------------------------------------|----------------------------------------------|
+| `--source <path>`  | CSV a procesar.                                                      | `/home/compustar/htdocs/ProductosHora.csv`   |
+| `--rows a-b`       | Subconjunto de filas (sin contar encabezado).                        | *(vacío → full)*                             |
+| `--dry-run 0|1`    | Propaga modo dry-run a Stage 10.                                     | `0`                                          |
+| `--wp-path <dir>`  | Ruta a WordPress.                                                    | `/home/compustar/htdocs`                     |
+| `--require-term 0|1` | Exigir categoría mapeada en Stage 04.                             | `1`                                          |
+
+Ejemplo rápido de ayuda:
+```bash
+scripts/run_compustar_import.sh --help
+```
+
+### 3.2 Variables de entorno
+
+Si existe `scripts/.env`, se carga automáticamente antes de parsear argumentos. Plantilla en `scripts/.env.example`:
+
+| Variable        | Uso                                                                 |
+|-----------------|---------------------------------------------------------------------|
+| `WP`, `REPO`, `WP_CLI`, `PLUG` | Rutas base para WordPress, repo y plugin.             |
+| `DRY_RUN`, `REQUIRE_TERM`, `ROWS`, `SOURCE` | Valores por defecto para la ejecución. |
+| `RUNS_TO_KEEP` | Número de runs a conservar (rotación simple).                        |
+
+Variables exportadas durante el run (disponibles para todos los Stages):
+
+- `RUN_DIR` / `RUN_PATH`
+- `RUN_ID`
+- `CSV_SRC`, `SOURCE_MASTER`, `CSV`
+- `FORCE_CSV=1`
+- `DRY_RUN`, `REQUIRE_TERM`
+- `LIMIT=0`
+- `STAGE_DEBUG=1`
+- `WP_PATH`, `WP_CLI`, `WP_PATH_ARGS="--no-color"`, `WP_TABLE_PREFIX`
+
+## 4. Ejecución manual
+
+### 4.1 Ejecución completa
+```bash
+cd /home/compustar/compustar-project
+scripts/run_compustar_import.sh --source /home/compustar/htdocs/ProductosHora.csv
+```
+
+### 4.2 Subset rápido (filas 1000-1050)
+```bash
+cd /home/compustar/compustar-project
+scripts/run_compustar_import.sh --rows 1000-1050
+```
+
+El script crea un RUN en `wp-content/uploads/compu-import/run-<epoch>` con subdirectorios `logs/` y `final/`. Cada stage escribe un log dedicado (`<stage-label>.log`) y la salida consolidada se encuentra en `logs/master.log`.
+
+## 5. Resultados esperados
+
+Artefactos obligatorios (el script aborta si alguno falta):
+
+- `source.csv`
+- `normalized.jsonl`
+- `validated.jsonl`
+- `resolved.jsonl`
+- `media.jsonl`
+- `final/import-report.json`
+- `final/postcheck.json`
+
+Artefactos adicionales generados por etapas intermedias: `final/unmapped.csv`, `final/invalid_term_ids.csv`, `final/stage04-metrics.json`, reportes de media y cualquier archivo creado por stages opcionales 08/09.
+
+## 6. Logs y monitoreo
+
+- Master log: `$RUN_DIR/logs/master.log`
+- Logs por stage: `$RUN_DIR/logs/<stage>.log` (por ejemplo `01-fetch.log`, `07-media.log`)
+- Logs especiales: Stage 07 escribe `stage07.log`, Stage 10 y 11 generan sus propios logs definidos por CLI.
+
+Para ver las últimas líneas de un stage:
+```bash
+tail -n 100 "$RUN_DIR/logs/07-media.log"
+```
+
+Para ver el resumen consolidado:
+```bash
+tail -n 200 "$RUN_DIR/logs/master.log"
+```
+
+## 7. Troubleshooting
+
+| Síntoma                              | Acción recomendada |
+|-------------------------------------|---------------------|
+| Falta `media.jsonl` tras Stage 07   | Verificar que `RUN_DIR` y `RUN_PATH` estén exportadas; revisar `$RUN_DIR/logs/07-media.log` para errores de WooCommerce. |
+| Stage 04 falla con `term_not_found` | Confirmar que la vista `wp_compu_cats_map` exista y contenga datos; validar la tabla `compu_cats_map`. |
+| `--wp-args` no aplicado             | Usar sintaxis con `=`: `--wp-args="--no-color"`. |
+| WP-CLI no encuentra instalación     | Ajustar `--wp-path` o `WP` en `.env`. |
+| Pre-flight falla por espacio        | Liberar espacio en `wp-content/uploads/compu-import`. |
+
+Consultas útiles con `jq`:
+```bash
+# Contar registros resueltos con categoría asignada
+jq -c '. | select(.resolution == "mapped")' "$RUN_DIR/resolved.jsonl" | wc -l
+
+# Listar filas sin categoría mapeada
+jq -r 'select(.resolution != "mapped") | .sku' "$RUN_DIR/resolved.jsonl"
+```
+
+## 8. Cron y automatización
+
+### 8.1 Cron diario
+Agregar al crontab del usuario `compustar` (`crontab -e`):
+```cron
+# Compustar — Import diario 02:15 AM
+15 2 * * * /home/compustar/compustar-project/scripts/run_compustar_import.sh --source /home/compustar/htdocs/ProductosHora.csv >> /var/log/compustar/import-$(date +\%Y\%m\%d).log 2>&1
+```
+El script ya gestiona `flock`, por lo que no es necesario envolver la ejecución.
+
+### 8.2 Systemd timer (opcional)
+Para entornos donde se prefiera systemd, se incluyen unidades de referencia en `systemd/compustar-import.service` y `systemd/compustar-import.timer`. Copiar a `/etc/systemd/system/`, ajustar rutas y habilitar manualmente (`systemctl enable --now compustar-import.timer`).
+
+## 9. Retención y housekeeping
+
+`RUNS_TO_KEEP` controla el número máximo de runs en `wp-content/uploads/compu-import`. El valor por defecto es `10`. El script elimina automáticamente los runs más antiguos tras cada ejecución exitosa, preservando siempre el actual.
+
+## 10. Concurrencia y seguridad
+
+- Se utiliza `flock` sobre `/var/lock/compu-import.lock` para evitar ejecuciones simultáneas.
+- Validaciones estrictas tras cada stage; el script retorna código distinto de cero si faltan artefactos obligatorios.
+- Pre-flight confirma comandos, espacio libre y estado de la base de datos (`wp db check`).
+
+## 11. Smoke test
+
+El script `tests/smoke_import.sh` permite validar rápidamente la configuración local usando un subconjunto de filas (`1000-1050`). Tras completarse, muestra un resumen de artefactos y un extracto de `import-report.json`.
+
+```bash
+cd /home/compustar/compustar-project
+tests/smoke_import.sh
+```
+
+## 12. Contacto y mantenimiento
+
+- Mantener actualizada la tabla `compu_cats_map` antes de correr Stage 04.
+- Revisar periódicamente los logs de Stage 10 y 11 para detectar banderas (`flags`) y diferencias (`diffs`).
+- Ante cambios en rutas o comandos, actualizar `scripts/.env` y la documentación correspondiente.

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -1,0 +1,14 @@
+# Rutas
+WP="/home/compustar/htdocs"
+REPO="/home/compustar/compustar-project"
+WP_CLI="/usr/local/bin/wp"
+PLUG="$WP/wp-content/plugins/compu-import-lego"
+
+# Orquestador
+DRY_RUN=0
+REQUIRE_TERM=1
+ROWS=""                 # ejemplo: 1000-1050
+SOURCE="/home/compustar/htdocs/ProductosHora.csv"
+
+# Retención
+RUNS_TO_KEEP=10

--- a/scripts/run_compustar_import.sh
+++ b/scripts/run_compustar_import.sh
@@ -1,0 +1,470 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+LOCK="/var/lock/compu-import.lock"
+exec 9>"$LOCK" || { echo "[FATAL] No se pudo abrir lock $LOCK"; exit 1; }
+if ! flock -n 9; then
+  echo "[LOCK] Otro proceso en ejecución." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Defaults
+WP_PATH="/home/compustar/htdocs"
+REPO="/home/compustar/compustar-project"
+WP_CLI="/usr/local/bin/wp"
+PHP_BIN="php"
+PYTHON_BIN="python3"
+SRC_DEFAULT="/home/compustar/htdocs/ProductosHora.csv"
+PLUG=""
+DRY_RUN=0
+REQUIRE_TERM=1
+ROWS=""
+SOURCE="$SRC_DEFAULT"
+RUNS_TO_KEEP=10
+PHP_OPTS=(-d display_errors=1 -d error_reporting=E_ALL -d memory_limit=1024M)
+RUN_BASE=""
+RUN_DIR=""
+RUN_ID=""
+MASTER_LOG=""
+WP_TABLE_PREFIX="wp_"
+
+ENV_FILE="$SCRIPT_DIR/.env"
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1091
+  set -a
+  source "$ENV_FILE"
+  set +a
+fi
+
+if [[ -n "${WP:-}" ]]; then
+  WP_PATH="$WP"
+fi
+
+usage() {
+  cat <<'USAGE'
+Uso: run_compustar_import.sh [opciones]
+  --source <ruta_csv>        Ruta al CSV de origen (default /home/compustar/htdocs/ProductosHora.csv)
+  --rows <ini-fin>           Rango opcional de filas (ej: 1000-1050) para subset
+  --dry-run {0|1}            Ejecuta Stage 10 en modo dry-run (default 0)
+  --wp-path <ruta>           Ruta a la instalación de WordPress (default /home/compustar/htdocs)
+  --require-term {0|1}       Requerir categoría mapeada en Stage 04 (default 1)
+  -h, --help                 Mostrar esta ayuda
+USAGE
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --source)
+        [[ $# -ge 2 ]] || { echo "Falta valor para --source" >&2; exit 2; }
+        SOURCE="$2"
+        shift 2
+        ;;
+      --rows)
+        [[ $# -ge 2 ]] || { echo "Falta valor para --rows" >&2; exit 2; }
+        ROWS="$2"
+        shift 2
+        ;;
+      --dry-run)
+        [[ $# -ge 2 ]] || { echo "Falta valor para --dry-run" >&2; exit 2; }
+        DRY_RUN="$2"
+        shift 2
+        ;;
+      --wp-path)
+        [[ $# -ge 2 ]] || { echo "Falta valor para --wp-path" >&2; exit 2; }
+        WP_PATH="$2"
+        shift 2
+        ;;
+      --require-term)
+        [[ $# -ge 2 ]] || { echo "Falta valor para --require-term" >&2; exit 2; }
+        REQUIRE_TERM="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --)
+        shift
+        break
+        ;;
+      *)
+        echo "Opción desconocida: $1" >&2
+        usage
+        exit 2
+        ;;
+    esac
+  done
+}
+
+log() {
+  local timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+  local message="$*"
+  if [[ -n "$MASTER_LOG" ]]; then
+    echo "[$timestamp] $message" | tee -a "$MASTER_LOG"
+  else
+    echo "[$timestamp] $message"
+  fi
+}
+
+die() {
+  local exit_code=${2:-1}
+  log "[ERROR] $1"
+  exit "$exit_code"
+}
+
+ensure_numeric_flag() {
+  local name="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^[01]$ ]]; then
+    die "Valor inválido para $name: $value (esperado 0 o 1)"
+  fi
+}
+
+mk_run_dir() {
+  PLUG="${PLUG:-"$WP_PATH/wp-content/plugins/compu-import-lego"}"
+  RUN_BASE="${WP_PATH}/wp-content/uploads/compu-import"
+  mkdir -p "$RUN_BASE"
+  local epoch
+  epoch="$(date +%s)"
+  while :; do
+    local candidate="$RUN_BASE/run-$epoch"
+    if [[ ! -e "$candidate" ]]; then
+      RUN_DIR="$candidate"
+      break
+    fi
+    epoch=$((epoch + 1))
+  done
+  RUN_ID="$(basename "$RUN_DIR")"
+  mkdir -p "$RUN_DIR" "$RUN_DIR/logs" "$RUN_DIR/final"
+  MASTER_LOG="$RUN_DIR/logs/master.log"
+  touch "$MASTER_LOG"
+  chmod 640 "$MASTER_LOG" 2>/dev/null || true
+}
+
+subset_csv() {
+  local range="$ROWS"
+  local src="$SOURCE"
+  [[ -f "$src" ]] || die "No se encontró el CSV fuente: $src"
+  if [[ -z "$range" ]]; then
+    CSV_SRC="$src"
+    SOURCE_MASTER="$src"
+    return
+  fi
+  if [[ ! "$range" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+    die "Formato inválido para --rows (esperado ini-fin): $range"
+  fi
+  local start="${BASH_REMATCH[1]}"
+  local end="${BASH_REMATCH[2]}"
+  if (( end < start )); then
+    die "El rango --rows debe tener inicio <= fin"
+  fi
+  local subset="$RUN_DIR/source_${start}-${end}.csv"
+  log "Generando subset $start-$end desde $src"
+  "$PYTHON_BIN" - "$src" "$subset" "$start" "$end" <<'PYCODE'
+import sys
+src, dest, start, end = sys.argv[1:5]
+start_i = int(start)
+end_i = int(end)
+written = 0
+with open(src, 'r', encoding='utf-8', errors='ignore') as fin, open(dest, 'w', encoding='utf-8', errors='ignore') as fout:
+    header = fin.readline()
+    if header:
+        fout.write(header)
+        written += 1
+    for idx, line in enumerate(fin, start=1):
+        if idx < start_i:
+            continue
+        if idx > end_i:
+            break
+        fout.write(line)
+        written += 1
+if written <= 1:
+    sys.stderr.write('Subset sin filas en el rango solicitado\n')
+    sys.exit(1)
+PYCODE
+  CSV_SRC="$subset"
+  SOURCE_MASTER="$subset"
+}
+
+ensure_command() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || die "Comando requerido no disponible: $cmd"
+}
+
+preflight_checks() {
+  log "== Pre-flight checks =="
+  ensure_command "$WP_CLI"
+  ensure_command "$PHP_BIN"
+  ensure_command "$PYTHON_BIN"
+  ensure_command jq
+
+  [[ -f "$CSV_SRC" ]] || die "CSV fuente no accesible: $CSV_SRC"
+
+  local available
+  available=$(df -Pk "$RUN_BASE" | awk 'NR==2 {print $4}')
+  if [[ -n "$available" ]] && (( available < 524288 )); then
+    die "Espacio libre insuficiente en $RUN_BASE (se requieren al menos 512 MB)"
+  fi
+
+  log "WP-CLI db check"
+  local wp_cmd=("$WP_CLI" "--path=$WP_PATH" "--no-color" db check)
+  if ! "${wp_cmd[@]}" >/dev/null; then
+    die "wp db check falló"
+  fi
+
+  log "Aplicando hotfix de vista wp_compu_cats_map"
+  local sql="CREATE OR REPLACE VIEW wp_compu_cats_map AS SELECT * FROM compu_cats_map;"
+  if ! "$WP_CLI" "--path=$WP_PATH" "--no-color" db query "$sql" >/dev/null; then
+    die "No se pudo crear/actualizar la vista wp_compu_cats_map"
+  fi
+
+  log "Pre-flight checks completados"
+}
+
+resolve_stage_script() {
+  local filename="$1"
+  local candidates=(
+    "$PLUG/stages/$filename"
+    "$PLUG/includes/stages/$filename"
+    "$REPO/server-mirror/compu-import-lego/includes/stages/$filename"
+  )
+  local path
+  for path in "${candidates[@]}"; do
+    if [[ -f "$path" ]]; then
+      echo "$path"
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_stage() {
+  local stage_label="$1"
+  shift
+  local stage_log="$RUN_DIR/logs/${stage_label}.log"
+  log "-- Ejecutando stage ${stage_label}"
+  if ! ("$@" 2>&1 | tee "$stage_log" | tee -a "$MASTER_LOG"); then
+    die "Stage ${stage_label} falló"
+  fi
+  log "-- Stage ${stage_label} completado"
+}
+
+ensure_file() {
+  local path="$1"
+  local message="$2"
+  if [[ ! -s "$path" ]]; then
+    die "$message"
+  fi
+}
+
+run_optional_stage() {
+  local label="$1"
+  shift
+  local script_name="$1"
+  shift
+  local script_path
+  if ! script_path=$(resolve_stage_script "$script_name"); then
+    log "Stage opcional $label omitido (no se encontró $script_name)"
+    return 0
+  fi
+  run_stage "$label" "$@" "$script_path"
+}
+
+summarize_artifact() {
+  local label="$1"
+  local path="$2"
+  if [[ -f "$path" ]]; then
+    local lines
+    if [[ "$path" == *.json || "$path" == *.jsonl ]]; then
+      lines=$(wc -l < "$path" 2>/dev/null || echo "N/A")
+    else
+      lines=$(wc -l < "$path" 2>/dev/null || echo "N/A")
+    fi
+    log "${label}: $path (lineas=${lines})"
+  else
+    log "${label}: NO ENCONTRADO ($path)"
+  fi
+}
+
+summary_report() {
+  log "== Resumen del run =="
+  summarize_artifact "source.csv" "$RUN_DIR/source.csv"
+  summarize_artifact "normalized.jsonl" "$RUN_DIR/normalized.jsonl"
+  summarize_artifact "validated.jsonl" "$RUN_DIR/validated.jsonl"
+  summarize_artifact "resolved.jsonl" "$RUN_DIR/resolved.jsonl"
+  summarize_artifact "media.jsonl" "$RUN_DIR/media.jsonl"
+  summarize_artifact "import-report.json" "$RUN_DIR/final/import-report.json"
+  summarize_artifact "postcheck.json" "$RUN_DIR/final/postcheck.json"
+
+  if command -v jq >/dev/null 2>&1; then
+    if [[ -f "$RUN_DIR/final/import-report.json" ]]; then
+      local flags
+      flags=$(jq -r 'if type=="object" and has("flags") then (.flags | to_entries | map("\(.key)=\(.value)") | join(", ")) else empty end' "$RUN_DIR/final/import-report.json" || true)
+      if [[ -n "$flags" ]]; then
+        log "Stage10 flags: $flags"
+      fi
+      local dry
+      dry=$(jq -r 'if type=="object" and has("dry_run") then ("dry_run=" + (if .dry_run then "yes" else "no" end)) else empty end' "$RUN_DIR/final/import-report.json" || true)
+      if [[ -n "$dry" ]]; then
+        log "Stage10 reporte: $dry"
+      fi
+    fi
+    if [[ -f "$RUN_DIR/final/postcheck.json" ]]; then
+      local diffs
+      diffs=$(jq -r 'if has("diffs") then ("diffs=" + ((.diffs | length) | tostring)) else empty end' "$RUN_DIR/final/postcheck.json" || true)
+      if [[ -n "$diffs" ]]; then
+        log "Stage11: $diffs"
+      fi
+    fi
+  fi
+
+  log "Dry-run flag: $DRY_RUN"
+  log "Run directory: $RUN_DIR"
+}
+
+rotate_runs() {
+  local keep="$RUNS_TO_KEEP"
+  if [[ -z "$keep" || ! "$keep" =~ ^[0-9]+$ ]]; then
+    return
+  fi
+  if (( keep <= 0 )); then
+    return
+  fi
+  local runs=()
+  while IFS= read -r line; do
+    runs+=("$line")
+  done < <(ls -1dt "$RUN_BASE"/run-* 2>/dev/null || true)
+  local total=${#runs[@]}
+  if (( total <= keep )); then
+    return
+  fi
+  for ((i=keep; i<total; i++)); do
+    local path="${runs[$i]}"
+    if [[ "$path" != "$RUN_DIR" && -d "$path" ]]; then
+      log "Eliminando run antiguo: $path"
+      rm -rf "$path"
+    fi
+  done
+}
+
+run_pipeline() {
+  ensure_numeric_flag "--dry-run" "$DRY_RUN"
+  ensure_numeric_flag "--require-term" "$REQUIRE_TERM"
+  mk_run_dir
+  trap 'status=$?; if [[ $status -ne 0 ]]; then log "Run abortado con código $status"; else log "Run finalizado con éxito"; fi' EXIT
+
+  subset_csv
+
+  export RUN_DIR
+  export RUN_PATH="$RUN_DIR"
+  export RUN_ID
+  export DRY_RUN REQUIRE_TERM
+  export LIMIT=0
+  export STAGE_DEBUG=1
+  export FORCE_CSV=1
+  export CSV_SRC SOURCE_MASTER
+  export SOURCE_MASTER
+  export CSV="$CSV_SRC"
+  export WP_PATH
+  export WP_CLI
+  export WP_PATH_ARGS="--no-color"
+  export WP_TABLE_PREFIX
+
+  log "== Inicio del run =="
+  log "Run ID: $RUN_ID"
+  log "Fuente: $CSV_SRC (rows=${ROWS:-'completo'})"
+  log "WP path: $WP_PATH"
+  log "Repo: $REPO"
+
+  preflight_checks
+
+  local stage_runner="$REPO/tests/stage_runner.php"
+  [[ -f "$stage_runner" ]] || die "No se encontró stage_runner.php en $stage_runner"
+
+  run_stage "01-fetch" "$PHP_BIN" "${PHP_OPTS[@]}" "$stage_runner" 01-fetch "--run-dir=$RUN_DIR" "--source=$CSV_SRC"
+  ensure_file "$RUN_DIR/source.csv" "Stage 01 no generó source.csv"
+
+  run_stage "02-normalize" "$PHP_BIN" "${PHP_OPTS[@]}" "$stage_runner" 02-normalize "--run-dir=$RUN_DIR"
+  ensure_file "$RUN_DIR/normalized.jsonl" "Stage 02 no generó normalized.jsonl"
+
+  run_stage "03-validate" "$PHP_BIN" "${PHP_OPTS[@]}" "$stage_runner" 03-validate "--run-dir=$RUN_DIR"
+  ensure_file "$RUN_DIR/validated.jsonl" "Stage 03 no generó validated.jsonl"
+
+  local stage04_script
+  if [[ -f "$REPO/python/python/stage04_resolve_map.py" ]]; then
+    stage04_script="$REPO/python/python/stage04_resolve_map.py"
+  else
+    stage04_script="$REPO/python/stage04_resolve_map.py"
+  fi
+  [[ -f "$stage04_script" ]] || die "No se encontró stage04_resolve_map.py"
+  run_stage "04-resolve" "$PYTHON_BIN" "$stage04_script" \
+    --run-dir "$RUN_DIR" \
+    --input "$RUN_DIR/validated.jsonl" \
+    --output "$RUN_DIR/resolved.jsonl" \
+    --log "$RUN_DIR/logs/stage04.log" \
+    --unmapped "$RUN_DIR/final/unmapped.csv" \
+    --invalid "$RUN_DIR/final/invalid_term_ids.csv" \
+    --metrics "$RUN_DIR/final/stage04-metrics.json" \
+    --wp-cli "$WP_CLI" \
+    --wp-path "$WP_PATH" \
+    --wp-args="--no-color" \
+    --table-prefix "$WP_TABLE_PREFIX" \
+    --require-term "$REQUIRE_TERM"
+  ensure_file "$RUN_DIR/resolved.jsonl" "Stage 04 no generó resolved.jsonl"
+
+  local stage05
+  stage05=$(resolve_stage_script "05-terms.php") || die "No se encontró stage 05"
+  run_stage "05-terms" "$WP_CLI" "--path=$WP_PATH" "--no-color" eval-file "$stage05"
+
+  local stage06
+  stage06=$(resolve_stage_script "06-products.php") || die "No se encontró stage 06"
+  run_stage "06-products" "$PHP_BIN" "${PHP_OPTS[@]}" "$stage06"
+
+  local stage07
+  stage07=$(resolve_stage_script "07-media.php") || die "No se encontró stage 07"
+  run_stage "07-media" "$WP_CLI" "--path=$WP_PATH" "--no-color" eval-file "$stage07"
+  ensure_file "$RUN_DIR/media.jsonl" "Stage 07 no generó media.jsonl"
+
+run_optional_stage "08-offers" "08-offers.php" "$WP_CLI" "--path=$WP_PATH" "--no-color" eval-file
+run_optional_stage "09-pricing" "09-pricing.php" "$WP_CLI" "--path=$WP_PATH" "--no-color" eval-file
+
+  local stage10_script
+  stage10_script="$REPO/python/stage10_import.py"
+  [[ -f "$stage10_script" ]] || die "No se encontró stage10_import.py"
+  run_stage "10-import" "$PYTHON_BIN" "$stage10_script" \
+    --run-dir "$RUN_DIR" \
+    --input "$RUN_DIR/resolved.jsonl" \
+    --log "$RUN_DIR/logs/stage10.log" \
+    --report "$RUN_DIR/final/import-report.json" \
+    --dry-run "$DRY_RUN" \
+    --writer wp \
+    --wp-path "$WP_PATH" \
+    --wp-args="--no-color" \
+    --run-id "$RUN_ID"
+  ensure_file "$RUN_DIR/final/import-report.json" "Stage 10 no generó final/import-report.json"
+
+  local stage11_script
+  stage11_script="$REPO/python/stage11_postcheck.py"
+  [[ -f "$stage11_script" ]] || die "No se encontró stage11_postcheck.py"
+  run_stage "11-postcheck" "$PYTHON_BIN" "$stage11_script" \
+    --run-dir "$RUN_DIR" \
+    --import-report "$RUN_DIR/final/import-report.json" \
+    --postcheck "$RUN_DIR/final/postcheck.json" \
+    --log "$RUN_DIR/logs/stage11.log" \
+    --dry-run "$DRY_RUN" \
+    --writer wp \
+    --wp-path "$WP_PATH" \
+    --wp-args="--no-color" \
+    --run-id "$RUN_ID"
+  ensure_file "$RUN_DIR/final/postcheck.json" "Stage 11 no generó final/postcheck.json"
+
+  summary_report
+  rotate_runs
+}
+
+parse_args "$@"
+run_pipeline

--- a/systemd/compustar-import.service
+++ b/systemd/compustar-import.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Compustar LEGO import orchestrator
+After=network-online.target mariadb.service mysqld.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=compustar
+Group=compustar
+WorkingDirectory=/home/compustar/compustar-project
+EnvironmentFile=-/home/compustar/compustar-project/scripts/.env
+ExecStart=/home/compustar/compustar-project/scripts/run_compustar_import.sh --source /home/compustar/htdocs/ProductosHora.csv
+StandardOutput=append:/var/log/compustar/import-systemd.log
+StandardError=append:/var/log/compustar/import-systemd.log

--- a/systemd/compustar-import.timer
+++ b/systemd/compustar-import.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily Compustar LEGO import (02:15)
+
+[Timer]
+OnCalendar=*-*-* 02:15:00
+Persistent=true
+RandomizedDelaySec=0
+
+[Install]
+WantedBy=timers.target

--- a/tests/smoke_import.sh
+++ b/tests/smoke_import.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$PROJECT_ROOT/scripts/.env"
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1091
+  set -a
+  source "$ENV_FILE"
+  set +a
+fi
+
+RUNNER="$PROJECT_ROOT/scripts/run_compustar_import.sh"
+if [[ ! -x "$RUNNER" ]]; then
+  echo "Runner no ejecutable: $RUNNER" >&2
+  exit 1
+fi
+
+TMP_OUTPUT="$(mktemp)"
+trap 'rm -f "$TMP_OUTPUT"' EXIT
+
+if ! "$RUNNER" --rows 1000-1050 "$@" | tee "$TMP_OUTPUT"; then
+  echo "Smoke test falló durante la ejecución del orquestador" >&2
+  exit 1
+fi
+
+RUN_DIR="$(grep -oE 'Run directory: .*' "$TMP_OUTPUT" | tail -n1 | sed 's/Run directory: //')"
+if [[ -z "$RUN_DIR" || ! -d "$RUN_DIR" ]]; then
+  WP_ROOT="${WP:-/home/compustar/htdocs}"
+  BASE="${WP_ROOT}/wp-content/uploads/compu-import"
+  RUN_DIR="$(ls -1dt "$BASE"/run-* 2>/dev/null | head -n1 || true)"
+fi
+
+if [[ -z "$RUN_DIR" || ! -d "$RUN_DIR" ]]; then
+  echo "No se pudo determinar el RUN_DIR generado" >&2
+  exit 1
+fi
+
+echo "== Smoke test summary ($RUN_DIR) =="
+for file in source.csv normalized.jsonl validated.jsonl resolved.jsonl media.jsonl final/import-report.json final/postcheck.json; do
+  path="$RUN_DIR/$file"
+  if [[ -f "$path" ]]; then
+    printf '%-28s %s\n' "$file" "$(wc -l < "$path" 2>/dev/null || echo 'N/A') líneas"
+  else
+    printf '%-28s %s\n' "$file" "(faltante)"
+  fi
+done
+
+REPORT="$RUN_DIR/final/import-report.json"
+if command -v jq >/dev/null 2>&1 && [[ -f "$REPORT" ]]; then
+  echo "-- Extracto import-report.json --"
+  jq -r 'if has("summary") then ("summary: " + (.summary | tojson)) else if has("flags") then ("flags: " + (.flags | tojson)) else (.[0:3] | tojson) end' "$REPORT"
+elif [[ -f "$REPORT" ]]; then
+  echo "-- import-report.json (primeras líneas) --"
+  head -n 20 "$REPORT"
+fi


### PR DESCRIPTION
## Summary
- add a bash orchestrator that runs stages 01–11 with logging, validation, retention and hotfix handling
- document the pipeline, configuration and automation options alongside an environment template
- provide a smoke test helper script and optional systemd timer/service stubs

## Testing
- bash -n scripts/run_compustar_import.sh
- bash -n tests/smoke_import.sh

------
https://chatgpt.com/codex/tasks/task_b_68e933c662c483209f961ee815bfa737