### PR TITLE
Fix Stage 07 to always generate media.jsonl and fail loudly when not possible

### DIFF
--- a/tests/smoke_import.sh
+++ b/tests/smoke_import.sh
@@ -18,10 +18,61 @@ if [[ ! -x "$RUNNER" ]]; then
   exit 1
 fi
 
-TMP_OUTPUT="$(mktemp)"
-trap 'rm -f "$TMP_OUTPUT"' EXIT
+MODE="rows"
+RUNNER_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      [[ $# -ge 2 ]] || { echo "Falta valor para --mode" >&2; exit 2; }
+      MODE="$2"
+      shift 2
+      ;;
+    *)
+      RUNNER_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
 
-if ! "$RUNNER" --rows 1000-1050 "$@" | tee "$TMP_OUTPUT"; then
+TMP_OUTPUT="$(mktemp)"
+TMP_FILES=("$TMP_OUTPUT")
+
+WP_ROOT="${WP:-/home/compustar/htdocs}"
+SOURCE_MASTER_PATH="${SOURCE_MASTER:-$WP_ROOT/ProductosHora.csv}"
+
+case "$MODE" in
+  rows)
+    RUN_COMMAND=("$RUNNER" --rows 1000-1050 "${RUNNER_ARGS[@]}")
+    ;;
+  random50)
+    if [[ ! -f "$SOURCE_MASTER_PATH" ]]; then
+      echo "No se encontró ProductosHora.csv en $SOURCE_MASTER_PATH" >&2
+      exit 1
+    fi
+    RANDOM_SOURCE="$(mktemp)"
+    TMP_FILES+=("$RANDOM_SOURCE")
+    {
+      head -n 1 "$SOURCE_MASTER_PATH"
+      tail -n +2 "$SOURCE_MASTER_PATH" | shuf -n 50
+    } > "$RANDOM_SOURCE"
+    echo "== Smoke mode: random50 (${SOURCE_MASTER_PATH} → $RANDOM_SOURCE) =="
+    RUN_COMMAND=("$RUNNER" --source "$RANDOM_SOURCE" "${RUNNER_ARGS[@]}")
+    ;;
+  *)
+    echo "Modo desconocido: $MODE" >&2
+    exit 2
+    ;;
+esac
+
+cleanup() {
+  local file
+  for file in "${TMP_FILES[@]}"; do
+    [[ -n "$file" ]] && rm -f "$file"
+  done
+}
+trap cleanup EXIT
+
+if ! "${RUN_COMMAND[@]}" | tee "$TMP_OUTPUT"; then
   echo "Smoke test falló durante la ejecución del orquestador" >&2
   exit 1
 fi
@@ -39,14 +90,20 @@ if [[ -z "$RUN_DIR" || ! -d "$RUN_DIR" ]]; then
 fi
 
 echo "== Smoke test summary ($RUN_DIR) =="
+missing=0
 for file in source.csv normalized.jsonl validated.jsonl resolved.jsonl media.jsonl final/import-report.json final/postcheck.json; do
   path="$RUN_DIR/$file"
   if [[ -f "$path" ]]; then
     printf '%-28s %s\n' "$file" "$(wc -l < "$path" 2>/dev/null || echo 'N/A') líneas"
   else
     printf '%-28s %s\n' "$file" "(faltante)"
+    missing=$((missing + 1))
   fi
 done
+if (( missing > 0 )); then
+  echo "Faltan artefactos obligatorios en $RUN_DIR" >&2
+  exit 1
+fi
 
 REPORT="$RUN_DIR/final/import-report.json"
 if command -v jq >/dev/null 2>&1 && [[ -f "$REPORT" ]]; then
@@ -56,3 +113,19 @@ elif [[ -f "$REPORT" ]]; then
   echo "-- import-report.json (primeras líneas) --"
   head -n 20 "$REPORT"
 fi
+
+MEDIA="$RUN_DIR/media.jsonl"
+if [[ -f "$MEDIA" ]]; then
+  echo "-- media.jsonl (primeras 3 líneas) --"
+  head -n 3 "$MEDIA"
+fi
+
+for stage_log in stage10 stage11; do
+  log_path="$RUN_DIR/logs/${stage_log}.log"
+  if [[ -f "$log_path" ]]; then
+    echo "-- tail ${stage_log}.log --"
+    tail -n 5 "$log_path"
+  else
+    echo "-- ${stage_log}.log no encontrado --"
+  fi
+done


### PR DESCRIPTION
## Summary
- ensure the Stage 07 script always runs under wp eval-file by defining COMP_RUN_STAGE when it is missing, log the start of processing with the resolved input and expected line count, and fail loudly if media.jsonl cannot be written
- add a random50 mode to tests/smoke_import.sh so the smoke test can sample 50 random products, verify required artefacts (including media.jsonl), and print media plus Stage 10/11 summaries
- expand the Stage 07 section of docs/runbook-import.md with the effective path, JSON structure, runtime validations, and common failure scenarios

## Reproduction
1. `cd /home/compustar/compustar-project`
2. `git pull --ff-only`
3. `rsync -av /home/compustar/compustar-project/server-mirror/compu-import-lego/ /home/compustar/htdocs/wp-content/plugins/compu-import-lego/`
4. `scripts/run_compustar_import.sh --rows 1000-1050 --dry-run 0`

## Testing
- `php -l server-mirror/compu-import-lego/includes/stages/07-media.php`
- `bash -n tests/smoke_import.sh`


------
https://chatgpt.com/codex/tasks/task_b_68e93f7a26a08320a1a6fcca54b9311f