### PR TITLE
Implement stage 10 fast apply executor with lower price rule

### DIFF
--- a/server-mirror/compu-import-lego/compu-import-lego/includes/stages/stage10_apply_fast.php
+++ b/server-mirror/compu-import-lego/compu-import-lego/includes/stages/stage10_apply_fast.php
@@ -1,0 +1,315 @@
+<?php
+if (!defined('COMP_RUN_STAGE')) {
+    define('COMP_RUN_STAGE', true);
+}
+
+if (php_sapi_name() !== 'cli' || (defined('WP_CLI') && !WP_CLI)) {
+    // Solo se ejecuta en CLI; si no, terminamos silenciosamente.
+    return;
+}
+
+if (!function_exists('wc_get_product_id_by_sku')) {
+    fwrite(STDERR, "[stage10] WooCommerce no está cargado.\n");
+    exit(1);
+}
+
+require_once ABSPATH . 'wp-admin/includes/post.php';
+require_once ABSPATH . 'wp-admin/includes/taxonomy.php';
+require_once ABSPATH . 'wp-admin/includes/media.php';
+require_once ABSPATH . 'wp-admin/includes/image.php';
+require_once ABSPATH . 'wp-admin/includes/file.php';
+
+function compu_stage10_read_payload(array $argv): array
+{
+    $args = array_slice($argv, 1);
+    if (!$args) {
+        throw new InvalidArgumentException('missing_payload');
+    }
+    $json = $args[0];
+    $data = json_decode($json, true);
+    if (!is_array($data)) {
+        throw new InvalidArgumentException('invalid_payload');
+    }
+    return $data;
+}
+
+function compu_stage10_format_float($value): float
+{
+    if ($value === null || $value === '') {
+        return 0.0;
+    }
+    return (float) $value;
+}
+
+function compu_stage10_format_int($value): int
+{
+    if ($value === null || $value === '') {
+        return 0;
+    }
+    return (int) round((float) $value);
+}
+
+function compu_stage10_output(array $result, int $exitCode = 0): void
+{
+    echo json_encode($result, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . PHP_EOL;
+    exit($exitCode);
+}
+
+function compu_stage10_current_price(int $productId): ?float
+{
+    $raw = get_post_meta($productId, '_compu_last_applied_price', true);
+    if ($raw === '') {
+        return null;
+    }
+    return (float) $raw;
+}
+
+function compu_stage10_update_price(int $productId, float $price, ?float $salePrice, array &$actions, array &$skipped): void
+{
+    $applied = false;
+    $current = compu_stage10_current_price($productId);
+    if ($current === null || $price < $current) {
+        $priceText = wc_format_decimal($price, 2);
+        update_post_meta($productId, '_regular_price', $priceText);
+        update_post_meta($productId, '_price', $priceText);
+        if ($salePrice !== null && $salePrice > 0 && $salePrice < $price) {
+            update_post_meta($productId, '_sale_price', wc_format_decimal($salePrice, 2));
+        } else {
+            delete_post_meta($productId, '_sale_price');
+        }
+        update_post_meta($productId, '_compu_last_applied_price', $priceText);
+        update_post_meta($productId, '_compu_last_applied_price_ts', gmdate('c'));
+        $actions[] = 'price_updated';
+        $applied = true;
+    } else {
+        $skipped[] = 'price_not_lower';
+    }
+
+    if ($applied) {
+        return;
+    }
+}
+
+function compu_stage10_assign_category(int $productId, $categoryTerm, array &$actions, array &$skipped, array &$errors): bool
+{
+    $termId = is_array($categoryTerm) ? ($categoryTerm['term_id'] ?? null) : $categoryTerm;
+    $termId = compu_stage10_format_int($termId);
+    if ($termId <= 0) {
+        $skipped[] = 'missing_category';
+        return false;
+    }
+    $result = wp_set_object_terms($productId, [$termId], 'product_cat', false);
+    if (is_wp_error($result)) {
+        $errors[] = 'category_assignment_failed:' . $result->get_error_code();
+        $skipped[] = 'missing_category';
+        return false;
+    }
+    $actions[] = 'cat_assigned';
+    return true;
+}
+
+function compu_stage10_set_stock(int $productId, array $payload, array &$actions): void
+{
+    $stock = compu_stage10_format_int($payload['stock'] ?? 0);
+    $status = $payload['stock_status'] ?? ($stock > 0 ? 'instock' : 'outofstock');
+    $status = in_array($status, ['instock', 'outofstock'], true) ? $status : ($stock > 0 ? 'instock' : 'outofstock');
+
+    update_post_meta($productId, '_manage_stock', 'yes');
+    update_post_meta($productId, '_stock', (string) $stock);
+    update_post_meta($productId, '_stock_status', $status);
+    update_post_meta($productId, '_backorders', 'no');
+    $actions[] = 'stock_set';
+}
+
+function compu_stage10_set_audit_meta(int $productId, array $payload, array &$actions): void
+{
+    update_post_meta($productId, '_compu_last_stage10', gmdate('c'));
+    if (!empty($payload['audit_hash'])) {
+        update_post_meta($productId, '_compu_import_hash', (string) $payload['audit_hash']);
+    }
+    $actions[] = 'audit_meta';
+}
+
+function compu_stage10_set_brand(int $productId, string $brand, array &$actions, array &$errors): void
+{
+    $brand = trim($brand);
+    if ($brand === '') {
+        return;
+    }
+    $term = term_exists($brand, 'product_brand');
+    if (!$term) {
+        $created = wp_insert_term($brand, 'product_brand');
+        if (is_wp_error($created)) {
+            $errors[] = 'brand_create_failed:' . $created->get_error_code();
+            return;
+        }
+        $termId = (int) ($created['term_id'] ?? 0);
+    } else {
+        $termId = (int) (is_array($term) ? ($term['term_id'] ?? 0) : $term);
+    }
+    if ($termId > 0) {
+        wp_set_object_terms($productId, [$termId], 'product_brand', false);
+        $actions[] = 'brand_assigned';
+    }
+}
+
+function compu_stage10_import_image(int $productId, string $imageUrl, string $title, array &$actions, array &$errors): void
+{
+    $imageUrl = trim($imageUrl);
+    if ($imageUrl === '') {
+        return;
+    }
+    $attachmentId = media_sideload_image($imageUrl, $productId, $title, 'id');
+    if (is_wp_error($attachmentId)) {
+        $errors[] = 'featured_image_failed:' . $attachmentId->get_error_code();
+        return;
+    }
+    set_post_thumbnail($productId, (int) $attachmentId);
+    $actions[] = 'featured_image_set';
+}
+
+function compu_stage10_publish(int $productId, array &$actions, array &$errors): void
+{
+    $result = wp_update_post([
+        'ID' => $productId,
+        'post_status' => 'publish',
+    ], true);
+    if (is_wp_error($result)) {
+        $errors[] = 'publish_failed:' . $result->get_error_code();
+        return;
+    }
+    $actions[] = 'published';
+}
+
+try {
+    $payload = compu_stage10_read_payload($argv);
+    $sku = isset($payload['sku']) ? trim((string) $payload['sku']) : '';
+    if ($sku === '') {
+        throw new InvalidArgumentException('missing_sku');
+    }
+
+    $result = [
+        'sku' => $sku,
+        'id' => null,
+        'actions' => [],
+        'skipped' => [],
+        'errors' => [],
+    ];
+
+    $shouldExist = !empty($payload['exists']);
+    $productId = 0;
+    if (!empty($payload['id'])) {
+        $productId = (int) $payload['id'];
+    }
+    if ($productId <= 0) {
+        $productId = wc_get_product_id_by_sku($sku) ?: 0;
+    }
+
+    if ($shouldExist && $productId <= 0) {
+        $result['skipped'][] = 'product_missing';
+        $result['errors'][] = 'product_not_found';
+        compu_stage10_output($result, 0);
+    }
+
+    if ($productId > 0) {
+        $result['id'] = $productId;
+        if (!compu_stage10_assign_category($productId, $payload['category_term'] ?? null, $result['actions'], $result['skipped'], $result['errors'])) {
+            compu_stage10_output($result, 0);
+        }
+        compu_stage10_set_stock($productId, $payload, $result['actions']);
+        $price = compu_stage10_format_float($payload['price'] ?? 0.0);
+        $salePrice = isset($payload['sale_price']) ? compu_stage10_format_float($payload['sale_price']) : null;
+        compu_stage10_update_price($productId, $price, $salePrice, $result['actions'], $result['skipped']);
+        compu_stage10_set_audit_meta($productId, $payload, $result['actions']);
+        compu_stage10_publish($productId, $result['actions'], $result['errors']);
+        $result['actions'][] = 'updated';
+        wc_delete_product_transients($productId);
+        compu_stage10_output($result, 0);
+    }
+
+    // Producto nuevo
+    if (!empty($payload['category_term'])) {
+        $categoryTermId = compu_stage10_format_int($payload['category_term']);
+        if ($categoryTermId <= 0) {
+            $result['skipped'][] = 'missing_category';
+            compu_stage10_output($result, 0);
+        }
+    } else {
+        $result['skipped'][] = 'missing_category';
+        compu_stage10_output($result, 0);
+    }
+
+    $title = isset($payload['title']) ? trim((string) $payload['title']) : '';
+    if ($title === '') {
+        $title = $sku;
+    }
+    $content = isset($payload['content']) ? (string) $payload['content'] : '';
+    $excerpt = isset($payload['excerpt']) ? (string) $payload['excerpt'] : '';
+    $slug = sanitize_title(isset($payload['slug']) ? (string) $payload['slug'] : $title);
+
+    $postId = wp_insert_post([
+        'post_title' => $title,
+        'post_content' => $content,
+        'post_excerpt' => $excerpt,
+        'post_status' => 'draft',
+        'post_type' => 'product',
+        'post_name' => $slug !== '' ? $slug : sanitize_title($title),
+    ], true);
+
+    if (is_wp_error($postId)) {
+        $result['errors'][] = 'create_failed:' . $postId->get_error_code();
+        compu_stage10_output($result, 1);
+    }
+
+    $productId = (int) $postId;
+    $result['id'] = $productId;
+
+    update_post_meta($productId, '_sku', $sku);
+
+    $categoryOk = compu_stage10_assign_category($productId, $payload['category_term'] ?? null, $result['actions'], $result['skipped'], $result['errors']);
+    if (!$categoryOk) {
+        wp_delete_post($productId, true);
+        compu_stage10_output($result, 0);
+    }
+
+    compu_stage10_set_stock($productId, $payload, $result['actions']);
+
+    $price = compu_stage10_format_float($payload['price'] ?? 0.0);
+    $salePrice = isset($payload['sale_price']) ? compu_stage10_format_float($payload['sale_price']) : null;
+    compu_stage10_update_price($productId, $price, $salePrice, $result['actions'], $result['skipped']);
+
+    wp_set_object_terms($productId, ['simple'], 'product_type', false);
+
+    if (!empty($payload['brand'])) {
+        compu_stage10_set_brand($productId, (string) $payload['brand'], $result['actions'], $result['errors']);
+    }
+
+    if (!empty($payload['image_url'])) {
+        compu_stage10_import_image($productId, (string) $payload['image_url'], $title, $result['actions'], $result['errors']);
+    }
+
+    compu_stage10_set_audit_meta($productId, $payload, $result['actions']);
+    compu_stage10_publish($productId, $result['actions'], $result['errors']);
+    $result['actions'][] = 'created';
+    wc_delete_product_transients($productId);
+
+    compu_stage10_output($result, 0);
+} catch (InvalidArgumentException $e) {
+    fwrite(STDERR, '[stage10] invalid input: ' . $e->getMessage() . "\n");
+    compu_stage10_output([
+        'sku' => null,
+        'id' => null,
+        'actions' => [],
+        'skipped' => [],
+        'errors' => ['invalid_input:' . $e->getMessage()],
+    ], 1);
+} catch (Throwable $e) {
+    fwrite(STDERR, '[stage10] fatal: ' . $e->getMessage() . "\n");
+    compu_stage10_output([
+        'sku' => null,
+        'id' => null,
+        'actions' => [],
+        'skipped' => [],
+        'errors' => ['exception:' . get_class($e)],
+    ], 1);
+}

--- a/tests/test_stage10_import.py
+++ b/tests/test_stage10_import.py
@@ -1,0 +1,291 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import List
+from unittest.mock import patch
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+PYTHON_DIR = ROOT_DIR / "python"
+for candidate in (ROOT_DIR, PYTHON_DIR):
+    candidate_str = str(candidate)
+    if candidate_str not in sys.path:
+        sys.path.insert(0, candidate_str)
+
+from python import stage10_import
+
+
+class Stage10ImportFastApplyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._orig_env = os.environ.copy()
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._orig_env)
+
+    def test_stage10_builds_payloads_and_updates_metrics(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_dir = Path(tmpdir) / "run"
+            input_path = run_dir / "input.jsonl"
+            log_path = run_dir / "logs" / "stage10.log"
+            report_path = run_dir / "reports" / "stage10-report.json"
+
+            run_dir.mkdir(parents=True, exist_ok=True)
+            (run_dir / "logs").mkdir(parents=True, exist_ok=True)
+            (run_dir / "reports").mkdir(parents=True, exist_ok=True)
+
+            records = [
+                {
+                    "sku": "SKU-LOWER",
+                    "price_16_final": 900,
+                    "Marca": "Acme",
+                    "stock_total_mayoristas": 12,
+                    "woo_product_id": 101,
+                    "category_term_id": 501,
+                    "Descripcion": "Desc one",
+                    "Imagen_Principal": "https://example.com/one.jpg",
+                    "audit_hash": "hash-lower",
+                },
+                {
+                    "sku": "SKU-EQUAL",
+                    "price_16_final": 1000,
+                    "Marca": "Acme",
+                    "stock_total_mayoristas": 8,
+                    "woo_product_id": 102,
+                    "category_term_id": 502,
+                    "Descripcion": "Desc two",
+                    "Imagen_Principal": "https://example.com/two.jpg",
+                    "audit_hash": "hash-equal",
+                },
+                {
+                    "sku": "SKU-HIGHER",
+                    "price_16_final": 1100,
+                    "Marca": "Acme",
+                    "stock_total_mayoristas": 5,
+                    "woo_product_id": 103,
+                    "category_term_id": 503,
+                    "Descripcion": "Desc three",
+                    "Imagen_Principal": "https://example.com/three.jpg",
+                    "audit_hash": "hash-higher",
+                },
+                {
+                    "sku": "SKU-NEW-GOOD",
+                    "price_16_final": 1200,
+                    "Marca": "NewBrand",
+                    "stock_total_mayoristas": 20,
+                    "category_term_id": 504,
+                    "Descripcion": "Desc four",
+                    "Imagen_Principal": "https://example.com/four.jpg",
+                    "audit_hash": "hash-new",
+                },
+                {
+                    "sku": "SKU-NEW-NOCAT",
+                    "price_16_final": 700,
+                    "Marca": "Other",
+                    "stock_total_mayoristas": 7,
+                    "Descripcion": "Desc five",
+                    "Imagen_Principal": "https://example.com/five.jpg",
+                    "audit_hash": "hash-nocat",
+                },
+            ]
+
+            with input_path.open("w", encoding="utf-8") as fh:
+                for record in records:
+                    fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+            os.environ["ST10_EXECUTOR_PATH"] = "/fake/stage10_apply_fast.php"
+            os.environ["WP_ROOT"] = "/fake/wp"
+
+            args = stage10_import.argparse.Namespace(
+                run_dir=str(run_dir),
+                input=str(input_path),
+                log=str(log_path),
+                report=str(report_path),
+                dry_run=0,
+                summary=[],
+                writer="wp",
+                wp_path="/usr/local/bin/wp",
+                wp_args="",
+                run_id="test-run",
+            )
+
+            responses: List[dict] = [
+                {
+                    "returncode": 0,
+                    "stdout": json.dumps(
+                        {
+                            "sku": "SKU-LOWER",
+                            "id": 101,
+                            "actions": [
+                                "price_updated",
+                                "stock_set",
+                                "cat_assigned",
+                                "audit_meta",
+                                "published",
+                                "updated",
+                            ],
+                            "skipped": [],
+                            "errors": [],
+                        }
+                    )
+                    + "\n",
+                    "stderr": "",
+                },
+                {
+                    "returncode": 0,
+                    "stdout": json.dumps(
+                        {
+                            "sku": "SKU-EQUAL",
+                            "id": 102,
+                            "actions": [
+                                "stock_set",
+                                "cat_assigned",
+                                "audit_meta",
+                                "published",
+                                "updated",
+                            ],
+                            "skipped": ["price_not_lower"],
+                            "errors": [],
+                        }
+                    )
+                    + "\n",
+                    "stderr": "",
+                },
+                {
+                    "returncode": 1,
+                    "stdout": "",
+                    "stderr": "simulated failure",
+                },
+                {
+                    "returncode": 0,
+                    "stdout": json.dumps(
+                        {
+                            "sku": "SKU-HIGHER",
+                            "id": 103,
+                            "actions": [
+                                "stock_set",
+                                "cat_assigned",
+                                "audit_meta",
+                                "published",
+                                "updated",
+                            ],
+                            "skipped": ["price_not_lower"],
+                            "errors": [],
+                        }
+                    )
+                    + "\n",
+                    "stderr": "",
+                },
+                {
+                    "returncode": 0,
+                    "stdout": json.dumps(
+                        {
+                            "sku": "SKU-NEW-GOOD",
+                            "id": 999,
+                            "actions": [
+                                "stock_set",
+                                "cat_assigned",
+                                "price_updated",
+                                "audit_meta",
+                                "published",
+                                "featured_image_set",
+                                "brand_assigned",
+                                "created",
+                            ],
+                            "skipped": [],
+                            "errors": [],
+                        }
+                    )
+                    + "\n",
+                    "stderr": "",
+                },
+                {
+                    "returncode": 0,
+                    "stdout": json.dumps(
+                        {
+                            "sku": "SKU-NEW-NOCAT",
+                            "id": None,
+                            "actions": [],
+                            "skipped": ["missing_category"],
+                            "errors": [],
+                        }
+                    )
+                    + "\n",
+                    "stderr": "",
+                },
+            ]
+
+            call_args: List[List[str]] = []
+            env_records: List[dict] = []
+
+            def fake_run(cmd, capture_output, text, env, timeout):
+                self.assertTrue(capture_output)
+                self.assertTrue(text)
+                self.assertEqual(timeout, 15)
+                call_args.append(cmd)
+                env_records.append(env)
+                response = responses.pop(0)
+                return stage10_import.subprocess.CompletedProcess(
+                    cmd, response["returncode"], response["stdout"], response["stderr"]
+                )
+
+            with patch("python.stage10_import.subprocess.run", side_effect=fake_run):
+                with patch("python.stage10_import.time.sleep") as fake_sleep:
+                    fake_sleep.return_value = None
+                    stage10_import.stage10(args)
+
+            self.assertFalse(responses)
+            self.assertGreaterEqual(len(call_args), 5)
+
+            for recorded_env in env_records:
+                self.assertEqual(recorded_env.get("ST10_SKIP_GALLERY"), "1")
+                self.assertEqual(recorded_env.get("ST10_SKIP_ATTRS"), "1")
+                self.assertEqual(recorded_env.get("ST10_BRAND_ONLY_ON_NEW"), "1")
+                self.assertEqual(recorded_env.get("ST10_ASSIGN_CATS_ONLY"), "1")
+                self.assertEqual(recorded_env.get("ST10_PRICE_RULE"), "LOWER_ONLY_META")
+                self.assertEqual(recorded_env.get("RUN_DIR"), str(run_dir))
+
+            self.assertTrue(all("--skip-themes" in cmd for cmd in call_args))
+            self.assertTrue(any("stage10_apply_fast.php" in " ".join(cmd) for cmd in call_args))
+
+            with log_path.open("r", encoding="utf-8") as fh:
+                log_lines = [json.loads(line) for line in fh if line.strip()]
+            self.assertEqual(len(log_lines), 5)
+
+            fast_log_path = run_dir / "logs" / "stage-10.log"
+            with fast_log_path.open("r", encoding="utf-8") as fh:
+                fast_lines = [json.loads(line) for line in fh if line.strip()]
+            self.assertEqual(log_lines, fast_lines)
+
+            with report_path.open("r", encoding="utf-8") as fh:
+                report_payload = json.load(fh)
+            metrics = report_payload["metrics"]
+
+            self.assertEqual(metrics["rows_total"], 5)
+            self.assertEqual(metrics["processed"], 5)
+            self.assertEqual(metrics["created"], 1)
+            self.assertEqual(metrics["updated"], 3)
+            self.assertEqual(metrics["skipped"], 1)
+            self.assertEqual(metrics["updated_price"], 2)
+            self.assertEqual(metrics["kept_price"], 2)
+            self.assertEqual(metrics["stock_set"], 4)
+            self.assertEqual(metrics["cat_assigned"], 4)
+            self.assertEqual(metrics["skipped_no_cat"], 1)
+            self.assertEqual(metrics["errors"], 0)
+
+            summary_path = run_dir / "summary.json"
+            with summary_path.open("r", encoding="utf-8") as fh:
+                summary = json.load(fh)
+            self.assertIn("stage_10", summary)
+            self.assertEqual(summary["stage_10"], metrics)
+
+            final_summary = run_dir / "final" / "summary.json"
+            with final_summary.open("r", encoding="utf-8") as fh:
+                final_data = json.load(fh)
+            self.assertIn("stage_10", final_data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the stage10_apply_fast.php executor that updates prices, inventory, categories, publication status and audit metadata while enforcing the lower-only price rule based on the _compu_last_applied_price meta
- rework python/stage10_import.py to emit per-SKU JSON payloads, call the new executor with retry/timeout handling, track the required metrics, and write stage-10.log alongside the existing report
- cover the new flow with tests/test_stage10_import.py to validate command construction, env flags, logging outputs and summary aggregation

## Testing
- python -m unittest tests.test_stage10_import
- php -l server-mirror/compu-import-lego/compu-import-lego/includes/stages/stage10_apply_fast.php


------
https://chatgpt.com/codex/tasks/task_b_68e9738a34048320a4c2c8bf8b8649c0