### PR TITLE
Add Stage 10 v2 executor and fast apply script

### DIFF
--- a/docs/stage10_v2.md
+++ b/docs/stage10_v2.md
@@ -1,0 +1,20 @@
+# Stage 10 v2
+
+Stage 10 v2 aplica los payloads JSONL contra WordPress/WooCommerce usando el script `python/stage10_v2.py` y el ejecutor rápido `stage10_apply_fast_v2.php`.
+
+## Variables de entorno
+
+- `ST10_V2`: habilita el uso del nuevo ejecutor desde `scripts/run_compustar_import.sh`.
+- `WP_BIN`: ruta al binario de WP-CLI (por defecto `/usr/local/bin/wp`).
+- `WP_PATH_ARGS`: argumentos extra para WP-CLI; si no incluyen `--path` se añade automáticamente con la ruta de WordPress.
+- `WP_ROOT`: ruta base de WordPress (por defecto `/home/compustar/htdocs`).
+- `ST10_FAST_PHP`: ruta alternativa al archivo `stage10_apply_fast_v2.php`.
+- `ST10_GUARD_PRICE_ZERO`: activa/desactiva el guardado de precios cero (por defecto activado).
+- `ST10_ALLOW_CREATE`: permite crear productos nuevos cuando no existen (desactivado por defecto).
+- `DRY_RUN`: si está activo, Stage 10 v2 no ejecuta WP-CLI y marca cada payload como `dry_run`.
+
+## Ejemplo
+
+```bash
+ST10_V2=1 scripts/run_compustar_import.sh --rows 1120-1135
+```

--- a/python/stage10_v2.py
+++ b/python/stage10_v2.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Stage 10 v2 executor for applying WooCommerce payloads via WP-CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+
+class Stage10Error(RuntimeError):
+    """Base error for Stage 10 v2."""
+
+
+class WPCLIError(Stage10Error):
+    """Raised when executing WP-CLI fails."""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Stage 10 v2 - WooCommerce fast apply")
+    parser.add_argument("--run-dir", required=True)
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--log", required=True)
+    parser.add_argument("--report", required=True)
+    parser.add_argument("--dry-run", type=int, choices=[0, 1], default=0)
+    parser.add_argument("--summary", action="append", default=[])
+    parser.add_argument("--writer", choices=["sim", "wp"], default=None)
+    parser.add_argument("--wp-path", dest="wp_path", default=None)
+    parser.add_argument("--wp-args", dest="wp_args", default=None)
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--fast-php", default=None)
+    return parser.parse_args()
+
+
+def env_flag(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    normalized = raw.strip().lower()
+    if normalized == "":
+        return default
+    return normalized in {"1", "true", "yes", "on"}
+
+
+def ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load_payloads(input_path: Path) -> List[Mapping[str, Any]]:
+    payloads: List[Mapping[str, Any]] = []
+    with input_path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                payload = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise Stage10Error(f"invalid_jsonl:{exc}") from exc
+            if not isinstance(payload, Mapping):
+                raise Stage10Error("invalid_payload_type")
+            payloads.append(payload)
+    return payloads
+
+
+def get_wp_bin() -> str:
+    candidate = os.environ.get("WP_BIN") or "/usr/local/bin/wp"
+    candidate_path = Path(candidate)
+    if candidate_path.is_dir():
+        raise Stage10Error(f"wp_bin_is_directory:{candidate}")
+    return candidate
+
+
+def build_wp_args(wp_root: Path) -> List[str]:
+    raw = os.environ.get("WP_PATH_ARGS", "")
+    args = shlex.split(raw) if raw else []
+    has_path = False
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token.startswith("--path="):
+            has_path = True
+            break
+        if token == "--path" and index + 1 < len(args):
+            has_path = True
+            break
+        index += 1
+    if not has_path:
+        args.append(f"--path={wp_root}")
+    return args
+
+
+def _looks_transient(stderr: str, stdout: str) -> bool:
+    text = f"{stderr}\n{stdout}".lower()
+    transient_markers = [
+        "another update is currently in progress",
+        "temporarily unavailable",
+        "timeout",
+        "connection reset",
+        "deadlock",
+    ]
+    return any(marker in text for marker in transient_markers)
+
+
+def _extract_last_json(stdout: str) -> Optional[MutableMapping[str, Any]]:
+    last: Optional[MutableMapping[str, Any]] = None
+    for line in stdout.splitlines():
+        text = line.strip()
+        if not text:
+            continue
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, MutableMapping):
+            last = parsed
+    return last
+
+
+def run_fast(payload: Mapping[str, Any], fast_php: str, wp_root: Path) -> Mapping[str, Any]:
+    if env_flag("DRY_RUN", False):
+        result: Dict[str, Any] = {
+            "sku": payload.get("sku"),
+            "id": payload.get("id"),
+            "actions": [],
+            "skipped": ["dry_run"],
+            "errors": [],
+        }
+        return result
+
+    wp_bin = get_wp_bin()
+    args = build_wp_args(wp_root)
+    print(
+        f"[FAST] resolve: wp_bin={wp_bin}, wp_root={wp_root}, args={' '.join(args)}",
+        file=sys.stderr,
+    )
+
+    payload_json = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    cmd = [
+        wp_bin,
+        "--no-color",
+        *args,
+        "eval-file",
+        fast_php,
+        "--",
+        payload_json,
+    ]
+    print(f"[FAST] exec: {shlex.join(cmd)}", file=sys.stderr)
+
+    attempts = 0
+    last_error: Optional[str] = None
+    while attempts < 2:
+        attempts += 1
+        try:
+            completed = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise WPCLIError(f"wp_cli_failed:{exc}") from exc
+
+        stdout = completed.stdout or ""
+        stderr = completed.stderr or ""
+        parsed = _extract_last_json(stdout)
+        if parsed is not None:
+            parsed.setdefault("actions", [])
+            parsed.setdefault("errors", [])
+            parsed.setdefault("skipped", [])
+            return dict(parsed)
+
+        message = stderr.strip() or stdout.strip() or f"rc={completed.returncode}"
+        last_error = message
+        if attempts < 2 and _looks_transient(stderr, stdout):
+            time.sleep(2)
+            continue
+        break
+
+    raise WPCLIError(f"wp_cli_failed:{last_error}")
+
+
+def update_metrics(metrics: MutableMapping[str, int], result: Mapping[str, Any]) -> None:
+    metrics["processed"] += 1
+
+    actions = [str(item) for item in result.get("actions", [])]
+    skipped = [str(item) for item in result.get("skipped", [])]
+    errors = [str(item) for item in result.get("errors", [])]
+
+    if "created" in actions:
+        metrics["created"] += 1
+    if "updated" in actions:
+        metrics["updated"] += 1
+    if "price_updated" in actions:
+        metrics["updated_price"] += 1
+    if "stock_set" in actions:
+        metrics["stock_set"] += 1
+    if "cat_assigned" in actions:
+        metrics["cat_assigned"] += 1
+    if any(flag in {"price_not_lower", "price_kept"} for flag in skipped):
+        metrics["kept_price"] += 1
+    if skipped:
+        metrics["skipped"] += 1
+    if errors:
+        metrics["errors"] += 1
+
+
+def collect_summary_paths(run_dir: Path, explicit: Iterable[str]) -> List[Path]:
+    paths = [Path(item) for item in explicit] if explicit else []
+    if not paths:
+        paths = [run_dir / "summary.json", run_dir / "final" / "summary.json"]
+    return paths
+
+
+def write_summary(paths: Iterable[Path], metrics: Mapping[str, Any]) -> None:
+    for path in paths:
+        ensure_parent(path)
+        if path.exists():
+            try:
+                with path.open("r", encoding="utf-8") as handle:
+                    existing = json.load(handle)
+            except (json.JSONDecodeError, OSError):
+                existing = {}
+        else:
+            existing = {}
+        if not isinstance(existing, MutableMapping):
+            existing = {}
+        existing["stage_10_v2"] = metrics
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(existing, handle, indent=2, ensure_ascii=False, sort_keys=True)
+
+
+def main() -> None:
+    args = parse_args()
+    run_dir = Path(args.run_dir)
+    input_path = Path(args.input)
+    log_path = Path(args.log)
+    report_path = Path(args.report)
+
+    if args.dry_run:
+        os.environ["DRY_RUN"] = "1"
+
+    if args.wp_args:
+        os.environ["WP_PATH_ARGS"] = args.wp_args
+
+    wp_root_str = args.wp_path or os.environ.get("WP_ROOT") or "/home/compustar/htdocs"
+    wp_root = Path(wp_root_str)
+
+    if not os.environ.get("ST10_GUARD_PRICE_ZERO"):
+        os.environ["ST10_GUARD_PRICE_ZERO"] = "1"
+
+    fast_php = (
+        args.fast_php
+        or os.environ.get("ST10_FAST_PHP")
+        or str(
+            wp_root
+            / "wp-content"
+            / "plugins"
+            / "compu-import-lego"
+            / "includes"
+            / "stages"
+            / "stage10_apply_fast_v2.php"
+        )
+    )
+    fast_php_path = Path(fast_php)
+    if not fast_php_path.exists():
+        raise Stage10Error(f"missing_fast_php:{fast_php}")
+    fast_php = str(fast_php_path)
+
+    ensure_parent(log_path)
+    ensure_parent(report_path)
+
+    if not input_path.exists():
+        raise Stage10Error(f"missing_input:{input_path}")
+    payloads = load_payloads(input_path)
+
+    results: List[Mapping[str, Any]] = []
+    metrics: Dict[str, int] = {
+        "processed": 0,
+        "created": 0,
+        "updated": 0,
+        "updated_price": 0,
+        "stock_set": 0,
+        "cat_assigned": 0,
+        "kept_price": 0,
+        "skipped": 0,
+        "errors": 0,
+    }
+
+    if not payloads:
+        empty_result = {"sku": None, "id": None, "actions": [], "skipped": ["no_records"], "errors": []}
+        results.append(empty_result)
+        with log_path.open("w", encoding="utf-8") as handle:
+            handle.write(json.dumps(empty_result, ensure_ascii=False) + "\n")
+        report_payload = {"results": results, "metrics": metrics}
+        with report_path.open("w", encoding="utf-8") as handle:
+            json.dump(report_payload, handle, indent=2, ensure_ascii=False, sort_keys=True)
+        write_summary(collect_summary_paths(run_dir, args.summary), metrics)
+        return
+
+    with log_path.open("w", encoding="utf-8") as log_handle:
+        for payload in payloads:
+            try:
+                result = run_fast(payload, fast_php, wp_root)
+            except WPCLIError as exc:
+                result = {
+                    "sku": payload.get("sku"),
+                    "id": payload.get("id"),
+                    "actions": [],
+                    "skipped": [],
+                    "errors": [str(exc)],
+                }
+            if not isinstance(result, dict):
+                result = dict(result)
+            result.setdefault("sku", payload.get("sku"))
+            if result.get("id") is None and payload.get("id") is not None:
+                result["id"] = payload.get("id")
+            results.append(result)
+            update_metrics(metrics, result)
+            log_handle.write(json.dumps(result, ensure_ascii=False) + "\n")
+
+    report_payload = {"results": results, "metrics": metrics}
+    with report_path.open("w", encoding="utf-8") as handle:
+        json.dump(report_payload, handle, indent=2, ensure_ascii=False, sort_keys=True)
+
+    write_summary(collect_summary_paths(run_dir, args.summary), metrics)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Stage10Error as exc:
+        print(f"[stage10_v2] {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/run_compustar_import.sh
+++ b/scripts/run_compustar_import.sh
@@ -433,8 +433,12 @@ run_optional_stage "08-offers" "08-offers.php" "$WP_CLI" "--path=$WP_PATH" "--no
 run_optional_stage "09-pricing" "09-pricing.php" "$WP_CLI" "--path=$WP_PATH" "--no-color" eval-file
 
   local stage10_script
-  stage10_script="$REPO/python/stage10_import.py"
-  [[ -f "$stage10_script" ]] || die "No se encontró stage10_import.py"
+  if [[ "${ST10_V2:-0}" == "1" ]]; then
+    stage10_script="$REPO/python/stage10_v2.py"
+  else
+    stage10_script="$REPO/python/stage10_import.py"
+  fi
+  [[ -f "$stage10_script" ]] || die "No se encontró stage10 (ruta: $stage10_script)"
   run_stage "10-import" "$PYTHON_BIN" "$stage10_script" \
     --run-dir "$RUN_DIR" \
     --input "$RUN_DIR/resolved.jsonl" \

--- a/server-mirror/compu-import-lego/compu-import-lego/includes/stages/stage10_apply_fast_v2.php
+++ b/server-mirror/compu-import-lego/compu-import-lego/includes/stages/stage10_apply_fast_v2.php
@@ -1,0 +1,288 @@
+<?php
+if (!defined('COMP_RUN_STAGE')) {
+    define('COMP_RUN_STAGE', true);
+}
+
+if (php_sapi_name() !== 'cli' || (defined('WP_CLI') && !WP_CLI)) {
+    return;
+}
+
+$result = [
+    'sku' => null,
+    'id' => null,
+    'actions' => [],
+    'skipped' => [],
+    'errors' => [],
+];
+
+$actions =& $result['actions'];
+$skipped =& $result['skipped'];
+$errors =& $result['errors'];
+
+function compu_stage10_v2_flag_enabled(string $name, bool $default = true): bool
+{
+    $raw = getenv($name);
+    if ($raw === false || $raw === '') {
+        return $default;
+    }
+    $normalized = strtolower(trim((string) $raw));
+    if ($normalized === '') {
+        return $default;
+    }
+    return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+}
+
+function compu_stage10_v2_truthy($value): ?bool
+{
+    if (is_bool($value)) {
+        return $value;
+    }
+    if (is_int($value)) {
+        return $value !== 0;
+    }
+    if (is_string($value)) {
+        $normalized = strtolower(trim($value));
+        if ($normalized === '') {
+            return null;
+        }
+        if (in_array($normalized, ['1', 'true', 'yes', 'on', 'y', 'si', 'sí'], true)) {
+            return true;
+        }
+        if (in_array($normalized, ['0', 'false', 'no', 'off', 'n'], true)) {
+            return false;
+        }
+    }
+    return null;
+}
+
+function compu_stage10_v2_output(array $result, int $exitCode = 0): void
+{
+    echo json_encode($result, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+    exit($exitCode);
+}
+
+function compu_stage10_v2_read_payload(array $argv): array
+{
+    $args = array_slice($argv, 1);
+    if (!$args) {
+        throw new InvalidArgumentException('missing_payload');
+    }
+    $json = $args[0];
+    $decoded = json_decode($json, true);
+    if (!is_array($decoded)) {
+        throw new InvalidArgumentException('invalid_payload');
+    }
+    return $decoded;
+}
+
+function compu_stage10_v2_extract_float($value): float
+{
+    if ($value === null || $value === '') {
+        return 0.0;
+    }
+    return (float) $value;
+}
+
+function compu_stage10_v2_extract_int($value): int
+{
+    if ($value === null || $value === '') {
+        return 0;
+    }
+    return (int) round((float) $value);
+}
+
+function compu_stage10_v2_pick_title(array $payload, string $fallback): string
+{
+    foreach (['name', 'title', 'Nombre', 'post_title'] as $key) {
+        if (!empty($payload[$key])) {
+            $candidate = trim((string) $payload[$key]);
+            if ($candidate !== '') {
+                return $candidate;
+            }
+        }
+    }
+    return $fallback;
+}
+
+function compu_stage10_v2_pick_content(array $payload): string
+{
+    foreach (['description', 'content', 'Descripcion', 'post_content'] as $key) {
+        if (!empty($payload[$key])) {
+            $candidate = trim((string) $payload[$key]);
+            if ($candidate !== '') {
+                return $candidate;
+            }
+        }
+    }
+    return '';
+}
+
+function compu_stage10_v2_assign_category(int $productId, int $termId, array &$actions, array &$skipped, array &$errors): void
+{
+    $result = wp_set_object_terms($productId, [$termId], 'product_cat', false);
+    if (is_wp_error($result)) {
+        $errors[] = 'category_assignment_failed:' . $result->get_error_code();
+        $skipped[] = 'missing_category';
+        return;
+    }
+    $actions[] = 'cat_assigned';
+}
+
+function compu_stage10_v2_set_stock(int $productId, array $payload, array &$actions): void
+{
+    $stock = compu_stage10_v2_extract_int($payload['stock'] ?? 0);
+    $status = isset($payload['stock_status']) ? strtolower((string) $payload['stock_status']) : '';
+    if ($status !== 'instock' && $status !== 'outofstock') {
+        $status = $stock > 0 ? 'instock' : 'outofstock';
+    }
+    $manage = compu_stage10_v2_truthy($payload['manage_stock'] ?? null);
+    $manage = $manage !== false;
+
+    update_post_meta($productId, '_manage_stock', $manage ? 'yes' : 'no');
+    update_post_meta($productId, '_stock', (string) max(0, $stock));
+    update_post_meta($productId, '_stock_status', $status);
+    update_post_meta($productId, '_backorders', 'no');
+    if (function_exists('wc_update_product_stock_status')) {
+        wc_update_product_stock_status($productId, $status);
+    }
+    $actions[] = 'stock_set';
+}
+
+function compu_stage10_v2_apply_price(int $productId, float $price, ?float $salePrice, array &$actions, array &$skipped): void
+{
+    $regularText = wc_format_decimal($price, 2);
+    if ($salePrice !== null && $salePrice > 0 && $salePrice < $price) {
+        $saleText = wc_format_decimal($salePrice, 2);
+        update_post_meta($productId, '_sale_price', $saleText);
+        update_post_meta($productId, '_price', $saleText);
+    } else {
+        delete_post_meta($productId, '_sale_price');
+        update_post_meta($productId, '_price', $regularText);
+        if ($salePrice !== null && $salePrice <= 0) {
+            $skipped[] = 'sale_price_invalid';
+        }
+    }
+    update_post_meta($productId, '_regular_price', $regularText);
+    update_post_meta($productId, '_compu_last_applied_price', $regularText);
+    update_post_meta($productId, '_compu_last_applied_price_ts', gmdate('c'));
+    $actions[] = 'price_updated';
+}
+
+function compu_stage10_v2_set_audit_meta(int $productId, array $payload, array &$actions): void
+{
+    update_post_meta($productId, '_compu_last_stage10', gmdate('c'));
+    if (!empty($payload['audit_hash'])) {
+        update_post_meta($productId, '_compu_import_hash', (string) $payload['audit_hash']);
+    }
+    $actions[] = 'audit_meta';
+}
+
+function compu_stage10_v2_create_product(array $payload, string $sku, array &$actions, array &$errors): int
+{
+    $title = compu_stage10_v2_pick_title($payload, $sku ?: 'Producto nuevo');
+    $postArgs = [
+        'post_title' => $title,
+        'post_type' => 'product',
+        'post_status' => 'draft',
+        'post_content' => compu_stage10_v2_pick_content($payload),
+    ];
+    $inserted = wp_insert_post($postArgs, true);
+    if (is_wp_error($inserted)) {
+        $errors[] = 'create_failed:' . $inserted->get_error_code();
+        return 0;
+    }
+    $productId = (int) $inserted;
+    if ($sku !== '') {
+        update_post_meta($productId, '_sku', $sku);
+    }
+    $actions[] = 'created';
+    return $productId;
+}
+
+try {
+    $payload = compu_stage10_v2_read_payload($argv);
+} catch (InvalidArgumentException $ex) {
+    $errors[] = 'invalid_payload:' . $ex->getMessage();
+    fwrite(STDERR, '[stage10_v2] payload error: ' . $ex->getMessage() . PHP_EOL);
+    compu_stage10_v2_output($result, 1);
+}
+
+$result['sku'] = isset($payload['sku']) ? (string) $payload['sku'] : '';
+
+if (!function_exists('wc_get_product_id_by_sku')) {
+    fwrite(STDERR, "[stage10_v2] WooCommerce no está cargado.\n");
+    $errors[] = 'woocommerce_not_loaded';
+    compu_stage10_v2_output($result, 1);
+}
+
+require_once ABSPATH . 'wp-admin/includes/post.php';
+require_once ABSPATH . 'wp-admin/includes/taxonomy.php';
+require_once ABSPATH . 'wp-admin/includes/media.php';
+require_once ABSPATH . 'wp-admin/includes/image.php';
+require_once ABSPATH . 'wp-admin/includes/file.php';
+
+$categoryTerm = compu_stage10_v2_extract_int($payload['category_term'] ?? 0);
+if ($categoryTerm <= 0) {
+    $skipped[] = 'skipped_no_cat';
+    compu_stage10_v2_output($result);
+}
+
+$price = compu_stage10_v2_extract_float($payload['price'] ?? null);
+if (compu_stage10_v2_flag_enabled('ST10_GUARD_PRICE_ZERO', true) && $price <= 0.0) {
+    $skipped[] = 'price_zero_guard';
+    compu_stage10_v2_output($result);
+}
+
+$salePrice = null;
+if (array_key_exists('sale_price', $payload)) {
+    $saleCandidate = compu_stage10_v2_extract_float($payload['sale_price']);
+    if ($saleCandidate > 0) {
+        $salePrice = $saleCandidate;
+    }
+}
+
+$productId = compu_stage10_v2_extract_int($payload['product_id'] ?? ($payload['id'] ?? 0));
+if ($productId <= 0 && $result['sku'] !== '') {
+    $productId = (int) wc_get_product_id_by_sku($result['sku']);
+}
+
+if ($productId <= 0) {
+    if (!compu_stage10_v2_flag_enabled('ST10_ALLOW_CREATE', false)) {
+        $skipped[] = 'missing_product';
+        compu_stage10_v2_output($result);
+    }
+    $productId = compu_stage10_v2_create_product($payload, $result['sku'], $actions, $errors);
+    if ($productId <= 0) {
+        compu_stage10_v2_output($result, 1);
+    }
+}
+
+$result['id'] = $productId;
+
+compu_stage10_v2_assign_category($productId, $categoryTerm, $actions, $skipped, $errors);
+compu_stage10_v2_set_stock($productId, $payload, $actions);
+compu_stage10_v2_apply_price($productId, $price, $salePrice, $actions, $skipped);
+compu_stage10_v2_set_audit_meta($productId, $payload, $actions);
+
+$currentStatus = get_post_status($productId) ?: 'draft';
+if ($currentStatus !== 'publish') {
+    $update = wp_update_post([
+        'ID' => $productId,
+        'post_status' => 'publish',
+    ], true);
+    if (is_wp_error($update)) {
+        $errors[] = 'publish_failed:' . $update->get_error_code();
+    } else {
+        $actions[] = 'published';
+    }
+}
+
+if (!in_array('created', $actions, true)) {
+    $actions[] = 'updated';
+}
+
+if (function_exists('wc_delete_product_transients')) {
+    wc_delete_product_transients($productId);
+}
+
+compu_stage10_v2_output($result);

--- a/tests/test_stage10_v2.py
+++ b/tests/test_stage10_v2.py
@@ -1,0 +1,61 @@
+import os
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from python import stage10_v2
+
+
+class Stage10V2Tests(unittest.TestCase):
+    def test_get_wp_bin_directory_error(self) -> None:
+        with patch.dict(os.environ, {"WP_BIN": "/tmp"}):
+            with self.assertRaises(stage10_v2.Stage10Error):
+                stage10_v2.get_wp_bin()
+
+    def test_build_wp_args_adds_path_when_missing(self) -> None:
+        with patch.dict(os.environ, {"WP_PATH_ARGS": "--skip-themes"}):
+            args = stage10_v2.build_wp_args(Path("/var/www"))
+        self.assertIn("--skip-themes", args)
+        self.assertIn("--path=/var/www", args)
+
+    def test_run_fast_parses_last_json_line(self) -> None:
+        payload = {"sku": "ABC123"}
+        stdout = "Notice: something\n{\"sku\":\"ABC123\",\"actions\":[\"updated\"],\"errors\":[]}\n"
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr=""
+        )
+        with patch.dict(os.environ, {"DRY_RUN": "0"}, clear=False):
+            with patch("python.stage10_v2.get_wp_bin", return_value="wp"):
+                with patch("python.stage10_v2.build_wp_args", return_value=["--path=/wp"]):
+                    with patch("python.stage10_v2.subprocess.run", return_value=completed) as fake_run:
+                        result = stage10_v2.run_fast(payload, "/tmp/fast.php", Path("/wp"))
+        self.assertEqual(result["sku"], "ABC123")
+        self.assertIn("updated", result["actions"])
+        fake_run.assert_called_once()
+        cmd = fake_run.call_args[0][0]
+        self.assertEqual(cmd[0], "wp")
+        self.assertIn("--no-color", cmd)
+        self.assertIn("eval-file", cmd)
+
+    def test_run_fast_raises_when_no_json(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="warning\n",
+            stderr="fatal error"
+        )
+        with patch.dict(os.environ, {"DRY_RUN": "0"}, clear=False):
+            with patch("python.stage10_v2.get_wp_bin", return_value="wp"):
+                with patch("python.stage10_v2.build_wp_args", return_value=["--path=/wp"]):
+                    with patch("python.stage10_v2.subprocess.run", return_value=completed):
+                        with self.assertRaises(stage10_v2.WPCLIError) as ctx:
+                            stage10_v2.run_fast({}, "/tmp/fast.php", Path("/wp"))
+        self.assertIn("wp_cli_failed", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Python Stage 10 v2 runner that resolves WP-CLI arguments, executes payloads and writes reports
- introduce the stage10_apply_fast_v2.php WooCommerce executor with category, stock and price handling
- gate the new workflow behind ST10_V2, document the environment flags and add unit tests for the new helpers

## Testing
- python3 -m unittest tests/test_stage10_v2.py

------
https://chatgpt.com/codex/tasks/task_b_68eaedb377b8832096dd8637ffa405f4