### PR TITLE
Refactor import launcher to use stage10 apply fast

### DIFF
--- a/tests/smoke_import.sh
+++ b/tests/smoke_import.sh
@@ -149,7 +149,7 @@ else
   exit 1
 fi
 
-for stage_log in stage10 stage11; do
+for stage_log in 10-apply-fast 11-postcheck; do
   log_path="$RUN_DIR/logs/${stage_log}.log"
   if [[ -f "$log_path" ]]; then
     echo "-- tail ${stage_log}.log --"


### PR DESCRIPTION
## Summary
- update the import launcher to run stage10_apply_fast_v2.php via WP-CLI, export required env vars, add database verification, and refresh run summaries
- adjust the smoke test to follow the new stage log naming
- document the stage10 apply fast workflow and logging expectations in the runbook

## Testing
- bash -n scripts/run_compustar_import.sh
- bash -n tests/smoke_import.sh

------
https://chatgpt.com/codex/tasks/task_b_68eeeee43cb883209c328800e180adbf